### PR TITLE
Markov chains + autoregressive HMM example for DNA sequences

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {Guillaume Dalle, Maxime Mouchet and contributors},
 	title   = {HiddenMarkovModels.jl},
 	url     = {https://github.com/gdalle/HiddenMarkovModels.jl},
-	version = {v0.2.0},
+	version = {v0.2.2},
 	year    = {2023},
 	month   = {7}
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HiddenMarkovModels"
 uuid = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
 authors = ["Guillaume Dalle", "Maxime Mouchet"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -25,20 +25,26 @@ using Distributions:
     MatrixDistribution
 using LinearAlgebra: Diagonal, dot, mul!
 using PrecompileTools: @compile_workload, @setup_workload
-using Random: AbstractRNG, GLOBAL_RNG
+using Random: AbstractRNG, default_rng
 using RequiredInterfaces: @required
 using Requires: @require
 using SimpleUnPack: @unpack
 using StatsAPI: StatsAPI, fit, fit!
 
 export HMMs
+export AbstractMarkovChain, AbstractMC
+export MarkovChain, MC
 export AbstractHiddenMarkovModel, AbstractHMM
 export HiddenMarkovModel, HMM
 export rand_prob_vec, rand_trans_mat
 export initial_distribution, transition_matrix, obs_distribution
 export logdensityof, viterbi, forward_backward, baum_welch
+export fit, fit!
 export LightDiagNormal
 
+include("interface.jl")
+include("abstract_mc.jl")
+include("mc.jl")
 include("abstract_hmm.jl")
 include("hmm.jl")
 

--- a/src/abstract_mc.jl
+++ b/src/abstract_mc.jl
@@ -1,0 +1,83 @@
+"""
+    AbstractMarkovChain
+
+Abstract supertype for a Markov chain amenable to simulation, inference and learning.
+
+# Required interface
+
+- `initial_distribution(mc)`
+- `transition_matrix(mc)`
+- `fit!(mc, init_count, trans_count)` (optional)
+
+# Applicable methods
+
+- `rand([rng,] mc, T)`
+- `logdensityof(mc, obs_seq)`
+- `fit(mc, obs_seq)` (if `fit!` is implemented)
+"""
+abstract type AbstractMarkovChain end
+
+"""
+    AbstractMC
+
+Alias for the type `AbstractMarkovChain`.
+"""
+const AbstractMC = AbstractMarkovChain
+
+@inline DensityInterface.DensityKind(::AbstractMC) = HasDensity()
+
+@required AbstractMC begin
+    Base.length(::AbstractMC)
+    initial_distribution(::AbstractMC)
+    transition_matrix(::AbstractMC)
+end
+
+function StatsAPI.fit!(mc::AbstractMC, state_seq::Vector{<:Integer})
+    return fit!(mc, [state_seq])
+end
+
+function StatsAPI.fit!(mc::AbstractMC, state_seqs::Vector{<:Vector{<:Integer}})
+    N = length(mc)
+    init_count = zeros(Int, N)
+    trans_count = zeros(Int, N, N)
+    for state_seq in state_seqs
+        init_count[first(state_seq)] += 1
+        for t in 1:(length(state_seq) - 1)
+            trans_count[state_seq[t], state_seq[t + 1]] += 1
+        end
+    end
+    return fit!(mc, init_count, trans_count)
+end
+
+function StatsAPI.fit(mc::AbstractMC, state_seq_or_seqs)
+    mc_est = deepcopy(mc)
+    fit!(mc_est, state_seq_or_seqs)
+    return mc_est
+end
+
+"""
+    rand(rng, mc, T)
+
+Simulate `mc` for `T` time steps with a specified `rng`.
+"""
+function Base.rand(rng::AbstractRNG, mc::AbstractMC, T::Integer)
+    init = initial_distribution(mc)
+    trans = transition_matrix(mc)
+    first_state = rand(rng, Categorical(init; check_args=false))
+    state_seq = Vector{Int}(undef, T)
+    state_seq[1] = first_state
+    @views for t in 2:T
+        state_seq[t] = rand(rng, Categorical(trans[state_seq[t - 1], :]; check_args=false))
+    end
+    return state_seq
+end
+
+function DensityInterface.logdensityof(mc::AbstractMC, state_seq::Vector{<:Integer})
+    init = initial_distribution(mc)
+    trans = transition_matrix(mc)
+    logL = log(init[first(state_seq)])
+    for t in 1:(length(state_seq) - 1)
+        logL += log(trans[state_seq[t], state_seq[t + 1]])
+    end
+    return logL
+end

--- a/src/hmm.jl
+++ b/src/hmm.jl
@@ -46,6 +46,11 @@ initial_distribution(hmm::HMM) = hmm.init
 transition_matrix(hmm::HMM) = hmm.trans
 obs_distribution(hmm::HMM, i::Integer) = hmm.dists[i]
 
+"""
+    StatsAPI.fit!(hmm::HMM, init_count, trans_count, obs_seq, state_marginals)
+
+Update `hmm` in-place based on information generated during forward-backward.
+"""
 function StatsAPI.fit!(hmm::HMM, init_count, trans_count, obs_seq, state_marginals)
     hmm.init .= init_count
     sum_to_one!(hmm.init)
@@ -55,4 +60,8 @@ function StatsAPI.fit!(hmm::HMM, init_count, trans_count, obs_seq, state_margina
         fit_element_from_sequence!(hmm.dists, i, obs_seq, state_marginals[i, :])
     end
     return nothing
+end
+
+function MarkovChain(hmm::AbstractHMM)
+    return MarkovChain(initial_distribution(hmm), transition_matrix(hmm))
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,0 +1,34 @@
+"""
+    length(model)
+
+Return the number of states of `model`.
+"""
+Base.length
+
+"""
+    initial_distribution(model)
+
+Return the initial state probabilities of `model`.
+"""
+function initial_distribution end
+
+"""
+    transition_matrix(model)
+
+Return the state transition probabilities of `model`.
+"""
+function transition_matrix end
+
+"""
+    rand(rng, model, T)
+
+Simulate `model` for `T` time steps with a specified `rng`.
+"""
+Base.rand
+
+"""
+    rand(model)
+
+Simulate `model` for `T` time steps with the default RNG.
+"""
+Base.rand(model, T::Integer) = rand(default_rng(), model, T)

--- a/src/mc.jl
+++ b/src/mc.jl
@@ -1,0 +1,29 @@
+struct MarkovChain{U<:AbstractVector,M<:AbstractMatrix} <: AbstractMarkovChain
+    init::U
+    trans::M
+
+    function MarkovChain(init::U, trans::M) where {U<:AbstractVector,M<:AbstractMatrix}
+        mc = new{U,M}(init, trans)
+        check_mc(mc)
+        return mc
+    end
+end
+
+const MC = MarkovChain
+
+Base.length(mc::MC) = length(mc.init)
+initial_distribution(mc::MC) = mc.init
+transition_matrix(mc::MC) = mc.trans
+
+"""
+    StatsAPI.fit!(mc::MC, init_count, trans_count)
+
+Update `mc` in-place based on information generated from a state sequence.
+"""
+function StatsAPI.fit!(mc::MC, init_count, trans_count)
+    mc.init .= init_count
+    sum_to_one!(mc.init)
+    mc.trans .= trans_count
+    foreach(sum_to_one!, eachrow(mc.trans))
+    return nothing
+end

--- a/src/utils/check.jl
+++ b/src/utils/check.jl
@@ -18,14 +18,24 @@ function check_dists(dists)
     end
 end
 
-function check_hmm(hmm::AbstractHMM)
-    init = initial_distribution(hmm)
-    trans = transition_matrix(hmm)
-    dists = [obs_distribution(hmm, i) for i in 1:length(hmm)]
-    if !(length(init) == size(trans, 1) == size(trans, 2) == length(dists))
+function check_mc(mc::MarkovChain)
+    init = initial_distribution(mc)
+    trans = transition_matrix(mc)
+    if !(length(init) == size(trans, 1) == size(trans, 2))
         throw(DimensionMismatch("Incoherent sizes"))
     end
     check_prob_vec(init)
     check_trans_mat(trans)
-    return check_dists(dists)
+    return nothing
+end
+
+function check_hmm(hmm::AbstractHMM)
+    mc = MarkovChain(initial_distribution(hmm), transition_matrix(hmm))
+    dists = [obs_distribution(hmm, i) for i in 1:length(hmm)]
+    if length(mc) != length(dists)
+        throw(DimensionMismatch("Incoherent sizes"))
+    end
+    check_mc(mc)
+    check_dists(dists)
+    return nothing
 end

--- a/src/utils/probvec.jl
+++ b/src/utils/probvec.jl
@@ -16,4 +16,4 @@ function rand_prob_vec(rng::AbstractRNG, N)
     return p
 end
 
-rand_prob_vec(N) = rand_prob_vec(GLOBAL_RNG, N)
+rand_prob_vec(N) = rand_prob_vec(default_rng(), N)

--- a/src/utils/transmat.jl
+++ b/src/utils/transmat.jl
@@ -37,4 +37,4 @@ function rand_trans_mat(rng::AbstractRNG, N)
     return A
 end
 
-rand_trans_mat(N) = rand_trans_mat(GLOBAL_RNG, N)
+rand_trans_mat(N) = rand_trans_mat(default_rng(), N)

--- a/test/correctness.jl
+++ b/test/correctness.jl
@@ -48,6 +48,7 @@ end
 
 N = 5
 D = 3
+T = 100
 
 p = rand_prob_vec(N)
 p_init = rand_prob_vec(N)
@@ -64,7 +65,7 @@ hmm_norm = HMM(p, A, dists_norm)
 hmm_norm_init = HMM(p_init, A_init, dists_norm_init)
 
 @testset verbose = true "Normal" begin
-    test_correctness(hmm_norm, hmm_norm_init; T=100)
+    test_correctness(hmm_norm, hmm_norm_init; T)
 end
 
 # DiagNormal
@@ -76,5 +77,5 @@ hmm_diagnorm = HMM(p, A, dists_diagnorm)
 hmm_diagnorm_init = HMM(p, A, dists_diagnorm_init)
 
 @testset verbose = true "DiagNormal" begin
-    test_correctness(hmm_diagnorm, hmm_diagnorm_init; T=100)
+    test_correctness(hmm_diagnorm, hmm_diagnorm_init; T)
 end

--- a/test/dna.jl
+++ b/test/dna.jl
@@ -129,7 +129,7 @@ dchmm = DNACodingHMM(;
     cod_init=rand_prob_vec(2),
     nuc_init=rand_prob_vec(4),
     cod_trans=rand_trans_mat(2),
-    nuc_trans=stack([rand_trans_mat(4), rand_trans_mat(4)]; dims=1),
+    nuc_trans=permutedims(cat(rand_trans_mat(4), rand_trans_mat(4); dims=3), (3, 1, 2)),
 );
 
 @unpack state_seq, obs_seq = rand(dchmm, 10_000);
@@ -144,10 +144,10 @@ dchmm_init = DNACodingHMM(;
     nuc_init=rand(4),
     cod_trans=rand_trans_mat(2),
     # using transition_matrix(mc) as initialization below seems to be worse
-    nuc_trans=stack([rand_trans_mat(4), rand_trans_mat(4)]; dims=1),
+    nuc_trans=permutedims(cat(rand_trans_mat(4), rand_trans_mat(4); dims=3), (3, 1, 2)),
 );
 
-dchmm_est, logL_evolution = baum_welch(dchmm_init, obs_seq; rtol=1e-5, max_iterations=100);
+dchmm_est, logL_evolution = baum_welch(dchmm_init, obs_seq; rtol=1e-7, max_iterations=100);
 
 logL_evolution
 

--- a/test/dna.jl
+++ b/test/dna.jl
@@ -1,0 +1,153 @@
+using DensityInterface
+using HiddenMarkovModels
+using Random: AbstractRNG
+using RequiredInterfaces: check_interface_implemented
+using StatsAPI
+using Test
+
+struct Dirac{T}
+    val::T
+end
+
+Base.rand(::AbstractRNG, d::Dirac) = d.val
+DensityInterface.DensityKind(::Dirac) = HasDensity()
+DensityInterface.logdensityof(d::Dirac, x) = x == d.val ? 0.0 : -Inf
+
+"""
+    DNACodingHMM <: AbstractHMM
+
+Custom implementation of an autoregressive HMM based on a standard HMM.
+
+This describes the behavior of DNA as it moves from coding to noncoding segments.
+In theory, the state is a character `coding` and the observation is a character `nucleotide`.
+In practice, the state is a character couple `(coding, nucleotide)` and the observation is the exact same `nucleotide`.
+
+# Notations
+
+Coding:
+
+| 1  | 2  |
+|----|----|
+| C  | N  |
+
+Emissions:
+
+| 1 | 2 | 3 | 4 |
+|---|---|---|---|
+| A | T | G | C |
+
+States:
+
+| 1     | 2     | 3     | 4     | 5     | 6     | 7     | 8     |
+|-------|-------|-------|-------|-------|-------|-------|-------|
+| (C,A) | (C,T) | (C,G) | (C,C) | (N,A) | (N,T) | (N,G) | (N,C) |
+
+# Fields
+
+- `cod_init::Vector{Float64}`: initial coding distribution
+- `nuc_init::Vector{Float64}`: initial nucleotide distribution
+- `cod_trans::Matrix{Float64}`: transition matrix between coding and noncoding
+- `nuc_trans::Array{Float64,2}`: pair of transition matrices between nucleotides in coding and noncoding state
+"""
+struct DNACodingHMM <: AbstractHMM
+    cod_init::Vector{Float64}
+    nuc_init::Vector{Float64}
+    cod_trans::Matrix{Float64}
+    nuc_trans::Array{Float64,3}
+    function DNACodingHMM(; cod_init, nuc_init, cod_trans, nuc_trans)
+        @assert length(cod_init) == 2
+        @assert length(nuc_init) == 4
+        @assert size(cod_trans) == (2, 2)
+        @assert size(nuc_trans) == (2, 4, 4)
+        return new(cod_init, nuc_init, cod_trans, nuc_trans)
+    end
+end
+
+get_coding(state) = 1 + (state - 1) ÷ 4
+get_nucleotide(state) = 1 + (state - 1) % 4
+get_state(coding, nucleotide) = 4(coding - 1) + nucleotide
+
+@test get_coding.(1:8) == repeat(1:2; inner=4)
+@test get_nucleotide.(1:8) == repeat(1:4; outer=2)
+@test get_state.(get_coding.(1:8), get_nucleotide.(1:8)) == collect(1:8)
+
+Base.length(dchmm::DNACodingHMM) = 8
+
+function HMMs.initial_distribution(dchmm::DNACodingHMM)
+    return repeat(dchmm.cod_init; inner=4) .* repeat(dchmm.nuc_init; outer=2)
+end
+
+function HMMs.transition_matrix(dchmm::DNACodingHMM)
+    (; cod_trans, nuc_trans) = dchmm
+    A = Matrix{Float64}(undef, 8, 8)
+    for c1 in 1:2, n1 in 1:4, c2 in 1:2, n2 in 1:4
+        s1, s2 = get_state(c1, n1), get_state(c2, n2)
+        A[s1, s2] = cod_trans[c1, c2] * nuc_trans[c1, n1, n2]
+    end
+    return A
+end
+
+function HMMs.obs_distribution(::DNACodingHMM, s::Integer)
+    return Dirac(get_nucleotide(s))
+end
+
+function StatsAPI.fit!(
+    dchmm::DNACodingHMM, init_count, trans_count, obs_seq, state_marginals
+)
+    # Initializations
+    for c in 1:2
+        dchmm.cod_init[c] = sum(init_count[get_state(c, n)] for n in 1:4)
+    end
+    for n in 1:4
+        dchmm.nuc_init[n] = sum(init_count[get_state(c, n)] for c in 1:2)
+    end
+    HMMs.sum_to_one!(dchmm.cod_init)
+    HMMs.sum_to_one!(dchmm.nuc_init)
+
+    # Transitions
+    for c1 in 1:2, c2 in 1:2
+        dchmm.cod_trans[c1, c2] = sum(
+            trans_count[get_state(c1, n1), get_state(c2, n2)] for n1 in 1:4, n2 in 1:4
+        )
+    end
+    for c1 in 1:2, n1 in 1:4, n2 in 1:4
+        dchmm.nuc_trans[c1, n1, n2] = sum(
+            trans_count[get_state(c1, n1), get_state(c2, n2)] for c2 in 1:2
+        )
+    end
+    foreach(HMMs.sum_to_one!, eachrow(dchmm.cod_trans))
+    foreach(HMMs.sum_to_one!, eachrow(@view dchmm.nuc_trans[1, :, :]))
+    foreach(HMMs.sum_to_one!, eachrow(@view dchmm.nuc_trans[2, :, :]))
+
+    return nothing
+end
+
+@test check_interface_implemented(AbstractHMM, DNACodingHMM)
+
+dchmm = DNACodingHMM(;
+    cod_init=rand(2),
+    nuc_init=rand(4),
+    cod_trans=rand_trans_mat(2),
+    nuc_trans=stack([rand_trans_mat(4), rand_trans_mat(4)]; dims=1),
+);
+
+dchmm_rand = DNACodingHMM(;
+    cod_init=rand(2),
+    nuc_init=rand(4),
+    cod_trans=rand_trans_mat(2),
+    nuc_trans=stack([rand_trans_mat(4), rand_trans_mat(4)]; dims=1),
+);
+
+(; state_seq, obs_seq) = rand(dchmm, 10_000);
+
+most_likely_coding_seq = get_coding.(viterbi(dchmm, obs_seq));
+
+dchmm_est, logL_evolution = baum_welch(dchmm_rand, obs_seq; rtol=1e-5, max_iterations=100);
+
+logL_evolution
+
+sum(abs, dchmm_rand.cod_trans - dchmm.cod_trans)
+sum(abs, dchmm_est.cod_trans - dchmm.cod_trans)
+
+sum(abs, dchmm_rand.nuc_trans - dchmm.nuc_trans)
+sum(abs, dchmm_est.nuc_trans - dchmm.nuc_trans)

--- a/test/dna.jl
+++ b/test/dna.jl
@@ -2,6 +2,7 @@ using DensityInterface
 using HiddenMarkovModels
 using Random: AbstractRNG
 using RequiredInterfaces: check_interface_implemented
+using SimpleUnPack
 using StatsAPI
 using Test
 
@@ -78,7 +79,7 @@ function HMMs.initial_distribution(dchmm::DNACodingHMM)
 end
 
 function HMMs.transition_matrix(dchmm::DNACodingHMM)
-    (; cod_trans, nuc_trans) = dchmm
+    @unpack cod_trans, nuc_trans = dchmm
     A = Matrix{Float64}(undef, 8, 8)
     for c1 in 1:2, n1 in 1:4, c2 in 1:2, n2 in 1:4
         s1, s2 = get_state(c1, n1), get_state(c2, n2)
@@ -131,7 +132,7 @@ dchmm = DNACodingHMM(;
     nuc_trans=stack([rand_trans_mat(4), rand_trans_mat(4)]; dims=1),
 );
 
-(; state_seq, obs_seq) = rand(dchmm, 10_000);
+@unpack state_seq, obs_seq = rand(dchmm, 10_000);
 
 most_likely_coding_seq = get_coding.(viterbi(dchmm, obs_seq));
 

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -6,6 +6,7 @@ using SimpleUnPack
 using Test
 
 N = 5
+T = 100
 
 p = rand_prob_vec(N)
 A = rand_trans_mat(N)
@@ -13,7 +14,7 @@ A = rand_trans_mat(N)
 dists = [Normal(μ[i], 1.0) for i in 1:N]
 hmm = HMM(p, A, dists)
 
-@unpack state_seq, obs_seq = rand(hmm, 100);
+@unpack state_seq, obs_seq = rand(hmm, T);
 
 function f(μ)
     new_dists = [Normal(μ[i], 1.0) for i in 1:N]

--- a/test/mc.jl
+++ b/test/mc.jl
@@ -1,0 +1,22 @@
+using HiddenMarkovModels
+using Test
+
+N = 5
+T = 100
+
+p = rand_prob_vec(N)
+p_rand = rand_prob_vec(N)
+
+A = rand_trans_mat(N)
+A_rand = rand_trans_mat(N)
+
+mc = MC(p, A)
+mc_rand = MC(p_rand, A_rand)
+
+state_seq = rand(mc, T)
+
+mc_est = fit(mc_rand, state_seq)
+
+@test logdensityof(mc_est, state_seq) >
+    logdensityof(mc, state_seq) >
+    logdensityof(mc_rand, state_seq)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,10 @@ using Test
         include("interface.jl")
     end
 
+    @testset "Markov chain" begin
+        include("mc.jl")
+    end
+
     @testset verbose = true "Correctness" begin
         include("correctness.jl")
     end
@@ -37,6 +41,10 @@ using Test
 
     @testset verbose = true "ForwardDiff" begin
         include("forwarddiff.jl")
+    end
+
+    @testset verbose = true "DNA" begin
+        include("dna.jl")
     end
 
     @testset "Doctests" begin

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -7,6 +7,7 @@ using SimpleUnPack
 using Test
 
 N = 5
+T = 1000
 
 p = ones(N) / N
 A = SparseMatrixCSC(SymTridiagonal(ones(N), ones(N - 1)))
@@ -17,7 +18,7 @@ dists_init = [Normal(randn(), 1.0) for i in 1:N]
 hmm = HMM(p, A, dists)
 hmm_init = HMM(p, A, dists_init)
 
-@unpack state_seq, obs_seq = rand(hmm, 1000)
+@unpack state_seq, obs_seq = rand(hmm, T)
 hmm_est, logL_evolution = @inferred baum_welch(hmm_init, obs_seq)
 
 @test typeof(hmm_est) == typeof(hmm)

--- a/test/static.jl
+++ b/test/static.jl
@@ -6,6 +6,7 @@ using SimpleUnPack
 using Test
 
 N = 5
+T = 1000
 
 p = MVector{N}(ones(N) / N)
 A = MMatrix{N,N}(rand_trans_mat(N))
@@ -15,7 +16,7 @@ dists_init = MVector{N}([Normal(randn(), 1.0) for i in 1:N])
 hmm = HMM(p, A, dists)
 hmm_init = HMM(p, A, dists_init)
 
-@unpack state_seq, obs_seq = rand(hmm, 1000)
+@unpack state_seq, obs_seq = rand(hmm, T)
 hmm_est, logL_evolution = @inferred baum_welch(hmm_init, obs_seq)
 
 @test typeof(hmm_est) == typeof(hmm)

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -22,6 +22,10 @@ end
     include("interface.jl")
 end
 
+@testitem "Markov chain" begin
+    include("mc.jl")
+end
+
 @testitem "Correctness" begin
     include("correctness.jl")
 end
@@ -36,6 +40,10 @@ end
 
 @testitem "ForwardDiff" begin
     include("forwarddiff.jl")
+end
+
+@testitem "DNA" begin
+    include("dna.jl")
 end
 
 @testset "Doctests" begin

--- a/test/type_stability.jl
+++ b/test/type_stability.jl
@@ -36,6 +36,8 @@ end
 
 N = 5
 D = 3
+T = 100
+K = 4
 
 p = rand_prob_vec(N)
 p_init = rand_prob_vec(N)
@@ -52,7 +54,7 @@ hmm_norm = HMM(p, A, dists_norm)
 hmm_norm_init = HMM(p_init, A_init, dists_norm_init)
 
 @testset verbose = true "Normal" begin
-    test_type_stability(hmm_norm, hmm_norm_init; T=100, K=3)
+    test_type_stability(hmm_norm, hmm_norm_init; T, K)
 end
 
 # DiagNormal
@@ -64,7 +66,7 @@ hmm_diagnorm = HMM(p, A, dists_diagnorm)
 hmm_diagnorm_init = HMM(p, A, dists_diagnorm_init)
 
 @testset verbose = true "DiagNormal" begin
-    test_type_stability(hmm_diagnorm, hmm_diagnorm_init; T=100, K=3)
+    test_type_stability(hmm_diagnorm, hmm_diagnorm_init; T, K)
 end
 
 ## LightDiagNormal
@@ -76,5 +78,5 @@ hmm_lightdiagnorm = HMM(p, A, dists_lightdiagnorm)
 hmm_lightdiagnorm_init = HMM(p, A, dists_lightdiagnorm_init)
 
 @testset verbose = true "LightDiagNormal" begin
-    test_type_stability(hmm_lightdiagnorm, hmm_lightdiagnorm_init; T=100, K=3)
+    test_type_stability(hmm_lightdiagnorm, hmm_lightdiagnorm_init; T, K)
 end


### PR DESCRIPTION
- Add `AbstractMarkovChain` and `MarkovChain` mirroring `AbstractHMM` and `HMM`
- Implement an example of autoregressive HMM for DNA with coding and noncoding states