### PR TITLE
Remove rtol in Baum-Welch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HiddenMarkovModels"
 uuid = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
 authors = ["Guillaume Dalle", "Maxime Mouchet"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/benchmark/utils/hmms.jl
+++ b/benchmark/utils/hmms.jl
@@ -46,7 +46,7 @@ function benchmarkables_hmms(; algos, N, D, T, K)
     end
     if "baum_welch" in algos
         benchs["baum_welch"] = @benchmarkable HMMs.baum_welch(
-            model, $obs_seqs, $K; max_iterations=BAUM_WELCH_ITER, rtol=-Inf
+            model, $obs_seqs, $K; max_iterations=BAUM_WELCH_ITER, atol=-Inf
         ) setup = (model = rand_model_hmms(; N=$N, D=$D))
     end
     return benchs

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -82,7 +82,7 @@ end
     logdensityof(hmm, obs_seq)
     viterbi(hmm, obs_seq)
     forward_backward(hmm, obs_seq)
-    baum_welch(hmm, obs_seq; max_iterations=2, rtol=-Inf)
+    baum_welch(hmm, obs_seq; max_iterations=2, atol=-Inf)
 end
 
 end

--- a/src/utils/fit.jl
+++ b/src/utils/fit.jl
@@ -3,10 +3,10 @@
 
 Modify the `i`-th element of `dists` by fitting it to an observation sequence `x` with associated weight sequence `w`.
 
-The default behavior is a fallback on `StatsAPI.fit!(dists[i], x, w)`, which users are encouraged to implement if their observation distributions are mutable.
-If not, check out the source code below to see the hack we used for Distributions.jl, and imitate it.
+The default behavior is a fallback on `StatsAPI.fit!`, which users are encouraged to implement if their observation distributions are mutable.
+If this is not possible, please override `fit_element_from_sequence!` directly.
 """
-function fit_element_from_sequence!(dists, i::Integer, x, w)
+function fit_element_from_sequence!(dists, i, x, w)
     fit!(dists[i], x, w)
     return nothing
 end

--- a/src/utils/probvec.jl
+++ b/src/utils/probvec.jl
@@ -1,5 +1,5 @@
-function is_prob_vec(p::AbstractVector; rtol=1e-2)
-    return (minimum(p) >= 0) && isapprox(sum(p), 1; rtol=rtol)
+function is_prob_vec(p::AbstractVector; atol=1e-2)
+    return (minimum(p) >= 0) && isapprox(sum(p), 1; atol=atol)
 end
 
 function check_prob_vec(p::AbstractVector)

--- a/src/utils/transmat.jl
+++ b/src/utils/transmat.jl
@@ -2,12 +2,12 @@ function is_square(A::AbstractMatrix)
     return size(A, 1) == size(A, 2)
 end
 
-function is_trans_mat(A::AbstractMatrix; rtol=1e-2)
+function is_trans_mat(A::AbstractMatrix; atol=1e-2)
     if !is_square(A)
         return false
     else
         for row in eachrow(A)
-            if !is_prob_vec(row; rtol=rtol)
+            if !is_prob_vec(row; atol=atol)
                 return false
             end
         end

--- a/test/correctness.jl
+++ b/test/correctness.jl
@@ -36,7 +36,7 @@ function test_correctness(hmm, hmm_init; T)
         )
         logL_evolution_base = hist_base.logtots
         hmm_est, logL_evolution = @inferred baum_welch(
-            hmm_init, obs_seq; max_iterations=10, rtol=-Inf
+            hmm_init, obs_seq; max_iterations=10, atol=-Inf
         )
         @test isapprox(
             logL_evolution[(begin + 1):end], logL_evolution_base[begin:(end - 1)]

--- a/test/dna.jl
+++ b/test/dna.jl
@@ -147,7 +147,7 @@ dchmm_init = DNACodingHMM(;
     nuc_trans=permutedims(cat(rand_trans_mat(4), rand_trans_mat(4); dims=3), (3, 1, 2)),
 );
 
-dchmm_est, logL_evolution = baum_welch(dchmm_init, obs_seq; rtol=1e-7, max_iterations=100);
+dchmm_est, logL_evolution = baum_welch(dchmm_init, obs_seq; atol=1e-7, max_iterations=100);
 
 logL_evolution
 


### PR DESCRIPTION
Breaking change: replace `rtol` with `atol` in `baum_welch`

Bump version to 0.3.0