### PR TITLE
Decompose forward function into initialize, predict, update

### DIFF
--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -38,6 +38,7 @@ include("utils/lightdiagnormal.jl")
 include("utils/lightcategorical.jl")
 include("utils/limits.jl")
 
+include("inference/predict.jl")
 include("inference/forward.jl")
 include("inference/viterbi.jl")
 include("inference/forward_backward.jl")

--- a/src/inference/predict.jl
+++ b/src/inference/predict.jl
@@ -1,0 +1,17 @@
+function predict_next_state!(
+    next_state_marginals::AbstractVector{<:Real},
+    hmm::AbstractHMM,
+    current_state_marginals::AbstractVector{<:Real},
+    control=nothing,
+)
+    trans = transition_matrix(hmm, control)
+    mul!(next_state_marginals, transpose(trans), current_state_marginals)
+    return next_state_marginals
+end
+
+function predict_next_state(
+    hmm::AbstractHMM, current_state_marginals::AbstractVector{<:Real}, control=nothing
+)
+    next_state_marginals = similar(current_state_marginals)
+    return predict_next_state!(next_state_marginals, hmm, current_state_marginals, control)
+end

--- a/src/inference/predict.jl
+++ b/src/inference/predict.jl
@@ -8,10 +8,3 @@ function predict_next_state!(
     mul!(next_state_marginals, transpose(trans), current_state_marginals)
     return next_state_marginals
 end
-
-function predict_next_state(
-    hmm::AbstractHMM, current_state_marginals::AbstractVector{<:Real}, control=nothing
-)
-    next_state_marginals = similar(current_state_marginals)
-    return predict_next_state!(next_state_marginals, hmm, current_state_marginals, control)
-end

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -72,6 +72,9 @@ log_initialization(hmm::AbstractHMM) = elementwise_log(initialization(hmm))
     transition_matrix(hmm, control)
 
 Return the matrix of state transition probabilities for `hmm` (possibly when `control` is applied).
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t` to `t+1` (and not from time `t-1` to `t`).
 """
 function transition_matrix end
 
@@ -82,6 +85,9 @@ function transition_matrix end
 Return the matrix of state transition log-probabilities for `hmm` (possibly when `control` is applied).
 
 Falls back on `transition_matrix`.
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t` to `t+1` (and not from time `t-1` to `t`).
 """
 function log_transition_matrix(hmm::AbstractHMM, control)
     return elementwise_log(transition_matrix(hmm, control))


### PR DESCRIPTION
As discussed in #104, this PR takes the existing forward filtering code and decomposes it into separate functions for initialising the filter, predicting the next state and updating the filtered state.

There are a few mildly ugly corners:
- `logL` is passed into `_update!` and returns. This is because the `logL` in storage is not updated until the full forward filtering is completed. This could be resolved by passing a `k` argument into `forward!` and updating `logL[k]` in-place but changing this signature had knock on effects on other algorithms (e.g. Baum-Welch) so I've left for now
- The prediction step is skipped for `t=1` since we just use the initialisation value. 

On the bright side, this decomposition has made the indexing a bit easier to understand. The loop is now `t1:t2` and the main index used is `t` rather than `t+1` before.

All correctness tests pass but there are few test cases in the AD/temporal examples that are failing. Happy to look into these but @gdalle might be able to instantly spot what's wrong.