### PR TITLE
Store transposed transition matrix to speed up forward

### DIFF
--- a/src/inference/forward.jl
+++ b/src/inference/forward.jl
@@ -70,9 +70,9 @@ function forward!(
         logm = maximum(Bₜ₊₁)
         Bₜ₊₁ .= exp.(Bₜ₊₁ .- logm)
 
-        trans = transition_matrix(hmm, control_seq[t])
+        transpose_trans = transpose_transition_matrix(hmm, control_seq[t])
         αₜ, αₜ₊₁ = view(α, :, t), view(α, :, t + 1)
-        mul!(αₜ₊₁, transpose(trans), αₜ)
+        mul!(αₜ₊₁, transpose_trans, αₜ)
         αₜ₊₁ .*= Bₜ₊₁
         c[t + 1] = inv(sum(αₜ₊₁))
         lmul!(c[t + 1], αₜ₊₁)

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -112,10 +112,10 @@ function obs_distributions end
 ## Fallbacks for no control
 
 transition_matrix(hmm::AbstractHMM, ::Nothing) = transition_matrix(hmm)
-transpose_transition_matrix(hmm::AbstractHMM, ::Nothing) = transpose_transition_matrix(hmm)
+transpose_transition_matrix(hmm::AbstractHMM, ::Nothing) = transpose(transition_matrix(hmm))
 log_transition_matrix(hmm::AbstractHMM, ::Nothing) = log_transition_matrix(hmm)
 function transpose_log_transition_matrix(hmm::AbstractHMM, ::Nothing)
-    return transpose_log_transition_matrix(hmm)
+    return transpose(log_transition_matrix(hmm))
 end
 obs_distributions(hmm::AbstractHMM, ::Nothing) = obs_distributions(hmm)
 

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -75,6 +75,10 @@ Return the matrix of state transition probabilities for `hmm` (possibly when `co
 """
 function transition_matrix end
 
+function transpose_transition_matrix(hmm::AbstractHMM, control)
+    return transpose(transition_matrix(hmm, control))
+end
+
 """
     log_transition_matrix(hmm)
     log_transition_matrix(hmm, control)
@@ -85,6 +89,10 @@ Falls back on `transition_matrix`.
 """
 function log_transition_matrix(hmm::AbstractHMM, control)
     return elementwise_log(transition_matrix(hmm, control))
+end
+
+function transpose_log_transition_matrix(hmm::AbstractHMM, control)
+    return transpose(log_transition_matrix(hmm, control))
 end
 
 """
@@ -104,7 +112,11 @@ function obs_distributions end
 ## Fallbacks for no control
 
 transition_matrix(hmm::AbstractHMM, ::Nothing) = transition_matrix(hmm)
+transpose_transition_matrix(hmm::AbstractHMM, ::Nothing) = transpose_transition_matrix(hmm)
 log_transition_matrix(hmm::AbstractHMM, ::Nothing) = log_transition_matrix(hmm)
+function transpose_log_transition_matrix(hmm::AbstractHMM, ::Nothing)
+    return transpose_log_transition_matrix(hmm)
+end
 obs_distributions(hmm::AbstractHMM, ::Nothing) = obs_distributions(hmm)
 
 """

--- a/src/utils/linalg.jl
+++ b/src/utils/linalg.jl
@@ -94,3 +94,6 @@ function argmaxplus_transmul!(
     end
     return y
 end
+
+concrete_transpose(A::AbstractMatrix) = convert(typeof(A), transpose(A))
+concrete_transpose(A::Transpose) = parent(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,9 @@ Pkg.develop(; path=joinpath(dirname(@__DIR__), "libs", "HMMTest"))
 
     @testset "Code linting" begin
         using Distributions
-        using Zygote
-        JET.test_package(HiddenMarkovModels; target_defined_modules=true)
+        if VERSION >= v"1.10"
+            JET.test_package(HiddenMarkovModels; target_defined_modules=true)
+        end
     end
 
     @testset "Distributions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ Pkg.develop(; path=joinpath(dirname(@__DIR__), "libs", "HMMTest"))
 
     @testset "Code linting" begin
         using Distributions
+        using Zygote
         if VERSION >= v"1.10"
             JET.test_package(HiddenMarkovModels; target_defined_modules=true)
         end


### PR DESCRIPTION
Fix #106 by storing a copy of the transposed transition matrix (and its elementwise logs) inside the concrete `HMM` type. To remain generic, I add methods for `AbstractHMM` that fall back on `transpose`.