### PR TITLE
Fix loglikelihood increase check in Baum-Welch

### DIFF
--- a/src/inference/baum_welch.jl
+++ b/src/inference/baum_welch.jl
@@ -73,7 +73,7 @@ function baum_welch(
         seq_ends,
         atol,
         max_iterations,
-        loglikelihood_increasing=false,
+        loglikelihood_increasing,
     )
     return hmm, logL_evolution
 end


### PR DESCRIPTION
The `loglikelihood_increasing` kwarg was erroneously ignored, this PR passes it correctly.