### PR TITLE
Disable multithreading when `seq_ends` is passed as a tuple

### DIFF
--- a/examples/controlled.jl
+++ b/examples/controlled.jl
@@ -94,7 +94,7 @@ function StatsAPI.fit!(
     fb_storage::HMMs.ForwardBackwardStorage,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVectorOrNTuple{Int},
+    seq_ends,
 ) where {T}
     (; γ, ξ) = fb_storage
     N = length(hmm)

--- a/examples/controlled.jl
+++ b/examples/controlled.jl
@@ -94,7 +94,7 @@ function StatsAPI.fit!(
     fb_storage::HMMs.ForwardBackwardStorage,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
 ) where {T}
     (; γ, ξ) = fb_storage
     N = length(hmm)

--- a/examples/interfaces.jl
+++ b/examples/interfaces.jl
@@ -186,7 +186,7 @@ function StatsAPI.fit!(
     hmm::PriorHMM,
     fb_storage::HiddenMarkovModels.ForwardBackwardStorage,
     obs_seq::AbstractVector;
-    seq_ends::AbstractVectorOrNTuple{Int},
+    seq_ends,
 )
     ## initialize to defaults without observations
     hmm.init .= 0

--- a/examples/interfaces.jl
+++ b/examples/interfaces.jl
@@ -186,7 +186,7 @@ function StatsAPI.fit!(
     hmm::PriorHMM,
     fb_storage::HiddenMarkovModels.ForwardBackwardStorage,
     obs_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
 )
     ## initialize to defaults without observations
     hmm.init .= 0

--- a/examples/temporal.jl
+++ b/examples/temporal.jl
@@ -109,7 +109,7 @@ function StatsAPI.fit!(
     fb_storage::HMMs.ForwardBackwardStorage,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
 ) where {T}
     (; γ, ξ) = fb_storage
     L, N = period(hmm), length(hmm)

--- a/examples/temporal.jl
+++ b/examples/temporal.jl
@@ -109,7 +109,7 @@ function StatsAPI.fit!(
     fb_storage::HMMs.ForwardBackwardStorage,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVectorOrNTuple{Int},
+    seq_ends,
 ) where {T}
     (; γ, ξ) = fb_storage
     L, N = period(hmm), length(hmm)

--- a/libs/HMMTest/src/HMMTest.jl
+++ b/libs/HMMTest/src/HMMTest.jl
@@ -2,6 +2,7 @@ module HMMTest
 
 using BenchmarkTools: @ballocated
 using HiddenMarkovModels
+using HiddenMarkovModels: AbstractVectorOrNTuple
 import HiddenMarkovModels as HMMs
 using HMMBase: HMMBase
 using JET: @test_opt, @test_call

--- a/libs/HMMTest/src/allocations.jl
+++ b/libs/HMMTest/src/allocations.jl
@@ -3,7 +3,7 @@ function test_allocations(
     rng::AbstractRNG,
     hmm::AbstractHMM,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
     hmm_guess::Union{Nothing,AbstractHMM}=nothing,
 )
     @testset "Allocations" begin

--- a/libs/HMMTest/src/coherence.jl
+++ b/libs/HMMTest/src/coherence.jl
@@ -55,7 +55,7 @@ function test_coherent_algorithms(
     rng::AbstractRNG,
     hmm::AbstractHMM,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
     hmm_guess::Union{Nothing,AbstractHMM}=nothing,
     atol::Real=0.05,
     init::Bool=true,

--- a/libs/HMMTest/src/jet.jl
+++ b/libs/HMMTest/src/jet.jl
@@ -3,7 +3,7 @@ function test_type_stability(
     rng::AbstractRNG,
     hmm::AbstractHMM,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
     hmm_guess::Union{Nothing,AbstractHMM}=nothing,
 )
     @testset "Type stability" begin

--- a/src/inference/baum_welch.jl
+++ b/src/inference/baum_welch.jl
@@ -73,7 +73,7 @@ function baum_welch(
         seq_ends,
         atol,
         max_iterations,
-        loglikelihood_increasing=false,
+        loglikelihood_increasing,
     )
     return hmm, logL_evolution
 end

--- a/src/inference/baum_welch.jl
+++ b/src/inference/baum_welch.jl
@@ -22,7 +22,7 @@ function baum_welch!(
     hmm::AbstractHMM,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
     atol::Real,
     max_iterations::Integer,
     loglikelihood_increasing::Bool,
@@ -55,7 +55,7 @@ function baum_welch(
     hmm_guess::AbstractHMM,
     obs_seq::AbstractVector,
     control_seq::AbstractVector=Fill(nothing, length(obs_seq));
-    seq_ends::AbstractVector{Int}=Fill(length(obs_seq), 1),
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
     atol=1e-5,
     max_iterations=100,
     loglikelihood_increasing=true,
@@ -85,7 +85,7 @@ function StatsAPI.fit!(
     fb_storage::ForwardBackwardStorage,
     obs_seq::AbstractVector,
     control_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
 )
     return fit!(hmm, fb_storage, obs_seq; seq_ends)
 end

--- a/src/inference/chainrules.jl
+++ b/src/inference/chainrules.jl
@@ -4,7 +4,7 @@ function _params_and_loglikelihoods(
     hmm::AbstractHMM,
     obs_seq::Vector,
     control_seq::AbstractVector=Fill(nothing, length(obs_seq));
-    seq_ends::AbstractVector{Int}=Fill(length(obs_seq), 1),
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
 )
     init = initialization(hmm)
     trans_by_time = mapreduce(_dcat, eachindex(control_seq)) do t
@@ -22,7 +22,7 @@ function ChainRulesCore.rrule(
     hmm::AbstractHMM,
     obs_seq::AbstractVector,
     control_seq::AbstractVector=Fill(nothing, length(obs_seq));
-    seq_ends::AbstractVector{Int}=Fill(length(obs_seq), 1),
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
 )
     _, pullback = rrule_via_ad(
         rc, _params_and_loglikelihoods, hmm, obs_seq, control_seq; seq_ends

--- a/src/inference/logdensity.jl
+++ b/src/inference/logdensity.jl
@@ -7,7 +7,7 @@ function DensityInterface.logdensityof(
     hmm::AbstractHMM,
     obs_seq::AbstractVector,
     control_seq::AbstractVector=Fill(nothing, length(obs_seq));
-    seq_ends::AbstractVector{Int}=Fill(length(obs_seq), 1),
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
 )
     _, logL = forward(hmm, obs_seq, control_seq; seq_ends)
     return sum(logL)
@@ -23,7 +23,7 @@ function joint_logdensityof(
     obs_seq::AbstractVector,
     state_seq::AbstractVector,
     control_seq::AbstractVector=Fill(nothing, length(obs_seq));
-    seq_ends::AbstractVector{Int}=Fill(length(obs_seq), 1),
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
 )
     R = eltype(hmm, obs_seq[1], control_seq[1])
     logL = zero(R)

--- a/src/types/hmm.jl
+++ b/src/types/hmm.jl
@@ -61,7 +61,7 @@ function StatsAPI.fit!(
     hmm::HMM,
     fb_storage::ForwardBackwardStorage,
     obs_seq::AbstractVector;
-    seq_ends::AbstractVector{Int},
+    seq_ends::AbstractVectorOrNTuple{Int},
 )
     (; γ, ξ) = fb_storage
     # Fit states

--- a/src/utils/limits.jl
+++ b/src/utils/limits.jl
@@ -3,7 +3,7 @@ $(SIGNATURES)
 
 Return a tuple `(t1, t2)` giving the begin and end indices of subsequence `k` within a set of sequences ending at `seq_ends`.
 """
-function seq_limits(seq_ends::AbstractVector{Int}, k::Integer)
+function seq_limits(seq_ends::AbstractVectorOrNTuple{Int}, k::Integer)
     if k == 1
         return 1, seq_ends[k]
     else

--- a/src/utils/linalg.jl
+++ b/src/utils/linalg.jl
@@ -1,3 +1,5 @@
+const AbstractVectorOrNTuple{T} = Union{AbstractVector{T},NTuple{N,T}} where {N}
+
 sum_to_one!(x) = ldiv!(sum(x), x)
 
 mynonzeros(x::AbstractArray) = x


### PR DESCRIPTION
This improves performance and type-stability for single-sequence routines by removing the overhead of `@threads`.