### PR TITLE
Pin JuliaFormatter to 1.0.62 and apply formatting

### DIFF
--- a/examples/gradientdescent.jl
+++ b/examples/gradientdescent.jl
@@ -53,7 +53,7 @@ Next, we provide the minimal interface expected by HiddenMarkovModels.jl:
 
 function DensityInterface.logdensityof(mod::NormalModel, obs::T) where {T<:Real}
     s = stddev(mod)
-    return - log(2π) / 2 - log(s) - ((obs - model_mean(mod)) / s)^2 / 2
+    return -log(2π) / 2 - log(s) - ((obs - model_mean(mod)) / s)^2 / 2
 end
 
 DensityInterface.DensityKind(::NormalModel) = DensityInterface.HasDensity()
@@ -120,8 +120,8 @@ Now that we have fully defined our observation model, we can create an HMM using
 
 init_dist = [0.2, 0.7, 0.1]
 init_trans = [
-    0.9 0.05 0.05;
-    0.075 0.9 0.025;
+    0.9 0.05 0.05
+    0.075 0.9 0.025
     0.1 0.1 0.8
 ]
 
@@ -146,8 +146,8 @@ gradient-based optimization (BFGS).
 
 init_dist_guess = fill(1.0 / 3, 3)
 init_trans_guess = [
-    0.98 0.01 0.01;
-    0.01 0.98 0.01;
+    0.98 0.01 0.01
+    0.01 0.98 0.01
     0.01 0.01 0.98
 ]
 

--- a/libs/HMMBenchmark/src/hiddenmarkovmodels.jl
+++ b/libs/HMMBenchmark/src/hiddenmarkovmodels.jl
@@ -110,11 +110,11 @@ function build_benchmarkables(
                 ),
                 evals = 1,
                 setup = (
-                    hmm_guess=build_model($implem, $instance, $params);
-                    fb_storage=initialize_forward_backward(
+                    hmm_guess = build_model($implem, $instance, $params);
+                    fb_storage = initialize_forward_backward(
                         hmm_guess, $obs_seq, $control_seq; seq_ends=($seq_ends)
                     );
-                    logL_evolution=Float64[];
+                    logL_evolution = Float64[];
                     sizehint!(logL_evolution, $bw_iter)
                 )
             )

--- a/libs/HMMComparison/src/dynamax.jl
+++ b/libs/HMMComparison/src/dynamax.jl
@@ -79,10 +79,10 @@ function HMMBenchmark.build_benchmarkables(
                 verbose=false,
             )
         end evals = 1 samples = 20 setup = (
-            tup=build_model($implem, $instance, $params);
-            hmm_guess=tup[1];
-            dyn_params_guess=tup[2];
-            dyn_props_guess=tup[3]
+            tup = build_model($implem, $instance, $params);
+            hmm_guess = tup[1];
+            dyn_params_guess = tup[2];
+            dyn_props_guess = tup[3]
         )
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -24,3 +24,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+JuliaFormatter = "1.0.62"


### PR DESCRIPTION
Resolves #151

I pinned to 1.0.62 as v2 is not considered stable by the devs of JuliaFormatter. Also, JET [loosened the JuliaSyntax](https://github.com/aviatesk/JET.jl/blob/master/Project.toml) requirement to "1, 2" so this should still play nicely with JET i believe