### PR TITLE
Add HSMM type hierarchy and simulation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -120,6 +120,8 @@ HiddenMarkovModels.duration_logdensityof
 HiddenMarkovModels.rand_duration
 HiddenMarkovModels.AbstractHSMM
 HiddenMarkovModels.HSMM
+HiddenMarkovModels.duration_distributions
+HiddenMarkovModels.valid_hsmm
 ```
 
 ## Index

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,6 +118,8 @@ HiddenMarkovModels.ControlBoundEmission
 HiddenMarkovModels.ControlBoundEmissionVector
 HiddenMarkovModels.duration_logdensityof
 HiddenMarkovModels.rand_duration
+HiddenMarkovModels.AbstractHSMM
+HiddenMarkovModels.HSMM
 ```
 
 ## Index

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -24,6 +24,7 @@ seq_ends = cumsum(length.(obs_seqs))
 ## Types
 
 ```@docs
+AbstractLatentStateModel
 AbstractHMM
 HMM
 ControlledEmissionHMM

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -24,7 +24,6 @@ seq_ends = cumsum(length.(obs_seqs))
 ## Types
 
 ```@docs
-AbstractLatentStateModel
 AbstractHMM
 HMM
 ControlledEmissionHMM
@@ -119,6 +118,7 @@ HiddenMarkovModels.ControlBoundEmission
 HiddenMarkovModels.ControlBoundEmissionVector
 HiddenMarkovModels.duration_logdensityof
 HiddenMarkovModels.rand_duration
+HiddenMarkovModels.AbstractLatentStateModel
 HiddenMarkovModels.AbstractHSMM
 HiddenMarkovModels.HSMM
 HiddenMarkovModels.duration_distributions

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -23,7 +23,7 @@ using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange
 using StatsAPI: StatsAPI, fit, fit!
 using StatsFuns: log2π
 
-export AbstractLatentStateModel, AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
+export AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
 export ControlledEmission, ControlBoundEmission, ControlBoundEmissionVector
 export initialization, transition_matrix, obs_distributions, duration_distributions
 export fit!, logdensityof, joint_logdensityof

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -16,7 +16,7 @@ using ChainRulesCore: ChainRulesCore, NoTangent, RuleConfig, rrule_via_ad
 using DensityInterface: DensityInterface, DensityKind, HasDensity, NoDensity, logdensityof
 using DocStringExtensions
 using FillArrays: Fill
-using LinearAlgebra: Transpose, axpy!, dot, ldiv!, lmul!, mul!, parent
+using LinearAlgebra: Transpose, axpy!, diag, dot, ldiv!, lmul!, mul!, parent
 using ProgressLogging: @withprogress, @logprogress
 using Random: Random, AbstractRNG, default_rng
 using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange, rowvals

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -23,13 +23,14 @@ using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange
 using StatsAPI: StatsAPI, fit, fit!
 using StatsFuns: log2π
 
-export AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
+export AbstractLatentStateModel, AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
 export ControlledEmission, ControlBoundEmission, ControlBoundEmissionVector
 export initialization, transition_matrix, obs_distributions, duration_distributions
 export fit!, logdensityof, joint_logdensityof
 export viterbi, forward, forward_backward, baum_welch
 export seq_limits
 
+include("types/abstract_latent_state_model.jl")
 include("types/abstract_hsmm.jl")
 include("types/abstract_hmm.jl")
 

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -16,7 +16,7 @@ using ChainRulesCore: ChainRulesCore, NoTangent, RuleConfig, rrule_via_ad
 using DensityInterface: DensityInterface, DensityKind, HasDensity, NoDensity, logdensityof
 using DocStringExtensions
 using FillArrays: Fill
-using LinearAlgebra: Transpose, axpy!, diag, dot, ldiv!, lmul!, mul!, parent
+using LinearAlgebra: Transpose, axpy!, Diagonal, dot, ldiv!, lmul!, mul!, parent
 using ProgressLogging: @withprogress, @logprogress
 using Random: Random, AbstractRNG, default_rng
 using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange, rowvals

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -23,13 +23,14 @@ using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange
 using StatsAPI: StatsAPI, fit, fit!
 using StatsFuns: log2π
 
-export AbstractHMM, HMM, ControlledEmissionHMM
+export AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
 export ControlledEmission, ControlBoundEmission, ControlBoundEmissionVector
-export initialization, transition_matrix, obs_distributions
+export initialization, transition_matrix, obs_distributions, duration_distributions
 export fit!, logdensityof, joint_logdensityof
 export viterbi, forward, forward_backward, baum_welch
 export seq_limits
 
+include("types/abstract_hsmm.jl")
 include("types/abstract_hmm.jl")
 
 include("utils/linalg.jl")
@@ -51,5 +52,6 @@ include("inference/chainrules.jl")
 
 include("types/hmm.jl")
 include("types/controlled_emission_hmm.jl")
+include("types/hsmm.jl")
 
 end

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -22,20 +22,9 @@ Any `AbstractHMM` which satisfies the interface can be given to the following fu
 - [`viterbi`](@ref)
 - [`forward_backward`](@ref)
 - [`baum_welch`](@ref) (if `[fit!](@ref)` is implemented)
+
 """
-abstract type AbstractHMM <: AbstractHSMM end
-
-#=
-`AbstractHMM` is a subtype of [`AbstractHSMM`](@ref) purely for code reuse: the shared interface
-(`initialization`, `transition_matrix`, `obs_distributions`, `length`, `eltype`, no-control
-fallbacks, etc.) is inherited from [`AbstractHSMM`](@ref). An HMM encodes its sojourn behavior
-implicitly through the transition-matrix diagonal and does **not** implement
-[`duration_distributions`](@ref); regular HMM modeling, inference and learning are unaffected by
-the HSMM machinery.
-=#
-
-# No-op for duration distributions, since HMMs don't have them.
-duration_logdensity_type(::AbstractHMM, control) = Union{}
+abstract type AbstractHMM <: AbstractLatentStateModel end
 
 """
     StatsAPI.fit!(
@@ -56,6 +45,8 @@ StatsAPI.fit!
     rand([rng,] hmm, control_seq)
 
 Simulate `hmm` for `T` time steps, or when the sequence `control_seq` is applied.
+
+Return a named tuple `(; state_seq, obs_seq)`.
 """
 function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVector)
     T = length(control_seq)
@@ -82,9 +73,6 @@ function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVe
         dists = obs_distributions(hmm, control_seq[t])
         obs_seq[t] = rand(rng, dists[state_seq[t]])
     end
-    #=
-    Return a named tuple `(; state_seq, obs_seq)`. This is more specific than the [`AbstractHSMM`](@ref)
-    `rand` (which additionally returns a `duration_seq`), preserving the HMM's historical return shape.
-    =#
+
     return (; state_seq=state_seq, obs_seq=obs_seq)
 end

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -3,6 +3,13 @@
 
 Abstract supertype for an HMM amenable to simulation, inference and learning.
 
+`AbstractHMM` is a subtype of [`AbstractHSMM`](@ref) purely for code reuse: the shared interface
+(`initialization`, `transition_matrix`, `obs_distributions`, `length`, `eltype`, no-control
+fallbacks, etc.) is inherited from [`AbstractHSMM`](@ref). An HMM encodes its sojourn behavior
+implicitly through the transition-matrix diagonal and does **not** implement
+[`duration_distributions`](@ref); regular HMM modeling, inference and learning are unaffected by
+the HSMM machinery.
+
 # Interface
 
 To create your own subtype of `AbstractHMM`, you need to implement the following methods:
@@ -23,40 +30,9 @@ Any `AbstractHMM` which satisfies the interface can be given to the following fu
 - [`forward_backward`](@ref)
 - [`baum_welch`](@ref) (if `[fit!](@ref)` is implemented)
 """
-abstract type AbstractHMM end
+abstract type AbstractHMM <: AbstractHSMM end
 
-@inline DensityInterface.DensityKind(::AbstractHMM) = HasDensity()
-
-## Interface
-
-"""
-    length(hmm)
-
-Return the number of states of `hmm`.
-"""
-Base.length(hmm::AbstractHMM) = length(initialization(hmm))
-
-"""
-    eltype(hmm, obs, control)
-
-Return a type that can accommodate forward-backward computations for `hmm` on observations similar to `obs`.
-
-It is typically a promotion between the element type of the initialization, the element type of the transition matrix, and the type of an observation logdensity evaluated at `obs`.
-"""
-function Base.eltype(hmm::AbstractHMM, obs, control)
-    init_type = eltype(initialization(hmm))
-    trans_type = eltype(transition_matrix(hmm, control))
-    dist = obs_distributions(hmm, control)[1]
-    logdensity_type = typeof(logdensityof(dist, obs))
-    return promote_type(init_type, trans_type, logdensity_type)
-end
-
-"""
-    initialization(hmm)
-
-Return the vector of initial state probabilities for `hmm`.
-"""
-function initialization end
+## Log accessors
 
 """
     log_initialization(hmm)
@@ -66,52 +42,6 @@ Return the vector of initial state log-probabilities for `hmm`.
 Falls back on `initialization`.
 """
 log_initialization(hmm::AbstractHMM) = elementwise_log(initialization(hmm))
-
-"""
-    transition_matrix(hmm)
-    transition_matrix(hmm, control)
-
-Return the matrix of state transition probabilities for `hmm` (possibly when `control` is applied).
-
-!!! note
-    When processing sequences, the control at time `t` influences the transition from time `t` to `t+1` (and not from time `t-1` to `t`).
-"""
-function transition_matrix end
-
-"""
-    log_transition_matrix(hmm)
-    log_transition_matrix(hmm, control)
-
-Return the matrix of state transition log-probabilities for `hmm` (possibly when `control` is applied).
-
-Falls back on `transition_matrix`.
-
-!!! note
-    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
-"""
-function log_transition_matrix(hmm::AbstractHMM, control)
-    return elementwise_log(transition_matrix(hmm, control))
-end
-
-"""
-    obs_distributions(hmm)
-    obs_distributions(hmm, control)
-
-Return a vector of observation distributions, one for each state of `hmm` (possibly when `control` is applied).
-
-These distribution objects should implement
-
-- `Random.rand(rng, dist)` for sampling
-- `DensityInterface.logdensityof(dist, obs)` for inference
-- `StatsAPI.fit!(dist, obs_seq, weight_seq)` for learning
-"""
-function obs_distributions end
-
-## Fallbacks for no control
-
-transition_matrix(hmm::AbstractHMM, ::Nothing) = transition_matrix(hmm)
-log_transition_matrix(hmm::AbstractHMM, ::Nothing) = log_transition_matrix(hmm)
-obs_distributions(hmm::AbstractHMM, ::Nothing) = obs_distributions(hmm)
 
 """
     StatsAPI.fit!(
@@ -146,7 +76,8 @@ end
 
 Simulate `hmm` for `T` time steps, or when the sequence `control_seq` is applied.
 
-Return a named tuple `(; state_seq, obs_seq)`.
+Return a named tuple `(; state_seq, obs_seq)`. This is more specific than the [`AbstractHSMM`](@ref)
+`rand` (which additionally returns a `duration_seq`), preserving the HMM's historical return shape.
 """
 function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVector)
     T = length(control_seq)
@@ -176,23 +107,7 @@ function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVe
     return (; state_seq=state_seq, obs_seq=obs_seq)
 end
 
-function Random.rand(hmm::AbstractHMM, control_seq::AbstractVector)
-    return rand(default_rng(), hmm, control_seq)
-end
-
-function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, T::Integer)
-    return rand(rng, hmm, Fill(nothing, T))
-end
-
-function Random.rand(hmm::AbstractHMM, T::Integer)
-    return rand(hmm, Fill(nothing, T))
-end
-
-## Prior
-
-"""
-    logdensityof(hmm)
-
-Return the prior loglikelihood associated with the parameters of `hmm`.
-"""
-DensityInterface.logdensityof(hmm::AbstractHMM) = false
+# The `rand(hmm, control_seq)`, `rand(rng, hmm, T)`, and `rand(hmm, T)` wrappers are inherited from
+# `AbstractHSMM`. The inner `rand(rng, hmm, control_seq)` above is more specific than the
+# `AbstractHSMM` version, so those wrappers ultimately dispatch to it, preserving HMM's 2-tuple
+# `(state_seq, obs_seq)` return shape.

--- a/src/types/abstract_hmm.jl
+++ b/src/types/abstract_hmm.jl
@@ -3,13 +3,6 @@
 
 Abstract supertype for an HMM amenable to simulation, inference and learning.
 
-`AbstractHMM` is a subtype of [`AbstractHSMM`](@ref) purely for code reuse: the shared interface
-(`initialization`, `transition_matrix`, `obs_distributions`, `length`, `eltype`, no-control
-fallbacks, etc.) is inherited from [`AbstractHSMM`](@ref). An HMM encodes its sojourn behavior
-implicitly through the transition-matrix diagonal and does **not** implement
-[`duration_distributions`](@ref); regular HMM modeling, inference and learning are unaffected by
-the HSMM machinery.
-
 # Interface
 
 To create your own subtype of `AbstractHMM`, you need to implement the following methods:
@@ -32,16 +25,17 @@ Any `AbstractHMM` which satisfies the interface can be given to the following fu
 """
 abstract type AbstractHMM <: AbstractHSMM end
 
-## Log accessors
+#=
+`AbstractHMM` is a subtype of [`AbstractHSMM`](@ref) purely for code reuse: the shared interface
+(`initialization`, `transition_matrix`, `obs_distributions`, `length`, `eltype`, no-control
+fallbacks, etc.) is inherited from [`AbstractHSMM`](@ref). An HMM encodes its sojourn behavior
+implicitly through the transition-matrix diagonal and does **not** implement
+[`duration_distributions`](@ref); regular HMM modeling, inference and learning are unaffected by
+the HSMM machinery.
+=#
 
-"""
-    log_initialization(hmm)
-
-Return the vector of initial state log-probabilities for `hmm`.
-
-Falls back on `initialization`.
-"""
-log_initialization(hmm::AbstractHMM) = elementwise_log(initialization(hmm))
+# No-op for duration distributions, since HMMs don't have them.
+duration_logdensity_type(::AbstractHMM, control) = Union{}
 
 """
     StatsAPI.fit!(
@@ -55,19 +49,6 @@ This function is allowed to reuse `fb_storage` as a scratch space, so its conten
 """
 StatsAPI.fit!
 
-## Fill logdensities
-
-function obs_logdensities!(
-    logb::AbstractVector{T}, hmm::AbstractHMM, obs, control; error_if_not_finite::Bool=true
-) where {T}
-    dists = obs_distributions(hmm, control)
-    @simd for i in eachindex(logb, dists)
-        logb[i] = logdensityof(dists[i], obs)
-    end
-    error_if_not_finite && @argcheck maximum(logb) < typemax(T)
-    return nothing
-end
-
 ## Sampling
 
 """
@@ -75,9 +56,6 @@ end
     rand([rng,] hmm, control_seq)
 
 Simulate `hmm` for `T` time steps, or when the sequence `control_seq` is applied.
-
-Return a named tuple `(; state_seq, obs_seq)`. This is more specific than the [`AbstractHSMM`](@ref)
-`rand` (which additionally returns a `duration_seq`), preserving the HMM's historical return shape.
 """
 function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVector)
     T = length(control_seq)
@@ -104,10 +82,9 @@ function Random.rand(rng::AbstractRNG, hmm::AbstractHMM, control_seq::AbstractVe
         dists = obs_distributions(hmm, control_seq[t])
         obs_seq[t] = rand(rng, dists[state_seq[t]])
     end
+    #=
+    Return a named tuple `(; state_seq, obs_seq)`. This is more specific than the [`AbstractHSMM`](@ref)
+    `rand` (which additionally returns a `duration_seq`), preserving the HMM's historical return shape.
+    =#
     return (; state_seq=state_seq, obs_seq=obs_seq)
 end
-
-# The `rand(hmm, control_seq)`, `rand(rng, hmm, T)`, and `rand(hmm, T)` wrappers are inherited from
-# `AbstractHSMM`. The inner `rand(rng, hmm, control_seq)` above is more specific than the
-# `AbstractHSMM` version, so those wrappers ultimately dispatch to it, preserving HMM's 2-tuple
-# `(state_seq, obs_seq)` return shape.

--- a/src/types/abstract_hsmm.jl
+++ b/src/types/abstract_hsmm.jl
@@ -92,6 +92,16 @@ Return the number of states of `model` (any `AbstractHSMM`, including `AbstractH
 """
 Base.length(model::AbstractHSMM) = length(initialization(model))
 
+#= 
+We split out the the type handling for duration logdensities, since HMMs don't have 
+duration distributions. This allows [`AbstractHMM`](@ref) to inherit the `eltype`
+method defined here.
+=#
+function duration_logdensity_type(model::AbstractHSMM, control)
+    dist = duration_distributions(model, control)[1]
+    return typeof(duration_logdensityof(dist, 1))
+end
+
 """
     eltype(model, obs, control)
 
@@ -104,7 +114,9 @@ function Base.eltype(model::AbstractHSMM, obs, control)
     trans_type = eltype(transition_matrix(model, control))
     dist = obs_distributions(model, control)[1]
     logdensity_type = typeof(logdensityof(dist, obs))
-    return promote_type(init_type, trans_type, logdensity_type)
+    return promote_type(
+        init_type, trans_type, logdensity_type, duration_logdensity_type(model, control)
+    )
 end
 
 """
@@ -148,6 +160,19 @@ duration_distributions(model::AbstractHSMM, ::Nothing) = duration_distributions(
 Return the prior loglikelihood associated with the parameters of `model`.
 """
 DensityInterface.logdensityof(model::AbstractHSMM) = false
+
+## Fill logdensities
+
+function obs_logdensities!(
+    logb::AbstractVector{T}, hmm::AbstractHSMM, obs, control; error_if_not_finite::Bool=true
+) where {T}
+    dists = obs_distributions(hmm, control)
+    @simd for i in eachindex(logb, dists)
+        logb[i] = logdensityof(dists[i], obs)
+    end
+    error_if_not_finite && @argcheck maximum(logb) < typemax(T)
+    return nothing
+end
 
 ## Sampling
 

--- a/src/types/abstract_hsmm.jl
+++ b/src/types/abstract_hsmm.jl
@@ -1,0 +1,224 @@
+"""
+    AbstractHSMM
+
+Abstract supertype for a Hidden Semi-Markov Model amenable to simulation, inference and learning.
+
+An `AbstractHSMM` explicitly models state durations through a per-state duration distribution.
+Sojourn lengths are drawn from those distributions, so self-transitions in the transition matrix
+are forbidden (the diagonal must be zero).
+
+[`AbstractHMM`](@ref) is a subtype of `AbstractHSMM`: every HMM is mathematically an HSMM whose
+sojourn lengths follow a geometric distribution encoded by the diagonal of the transition matrix.
+The interface defined here is inherited by `AbstractHMM`.
+
+# Interface
+
+To create your own subtype of `AbstractHSMM`, you need to implement the following methods:
+
+- [`initialization`](@ref)
+- [`transition_matrix`](@ref)
+- [`obs_distributions`](@ref)
+- [`duration_distributions`](@ref)
+- [`fit!`](@ref) (for learning)
+
+# Applicable functions
+
+Any `AbstractHSMM` which satisfies the interface can be given to the following functions:
+
+- [`rand`](@ref)
+"""
+abstract type AbstractHSMM end
+
+@inline DensityInterface.DensityKind(::AbstractHSMM) = HasDensity()
+
+## Interface
+
+"""
+    initialization(model)
+
+Return the vector of initial state probabilities for `model` (any `AbstractHSMM`, including
+`AbstractHMM` subtypes).
+"""
+function initialization end
+
+"""
+    transition_matrix(model)
+    transition_matrix(model, control)
+
+Return the matrix of state transition probabilities for `model` (possibly when `control` is applied).
+
+For an [`AbstractHSMM`](@ref) the diagonal of this matrix must be zero (no self-transitions).
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
+"""
+function transition_matrix end
+
+"""
+    obs_distributions(model)
+    obs_distributions(model, control)
+
+Return a vector of observation distributions, one for each state of `model` (possibly when `control` is applied).
+
+These distribution objects should implement
+
+- `Random.rand(rng, dist)` for sampling
+- `DensityInterface.logdensityof(dist, obs)` for inference
+- `StatsAPI.fit!(dist, obs_seq, weight_seq)` for learning
+"""
+function obs_distributions end
+
+"""
+    duration_distributions(model)
+    duration_distributions(model, control)
+
+Return a vector of sojourn-time distributions, one for each state of `model` (possibly when
+`control` is applied).
+
+Following the convention of [`duration_logdensityof`](@ref) and [`rand_duration`](@ref), each
+distribution has support on `{0, 1, 2, ...}` and is interpreted as the law of `(sojourn time - 1)`.
+Any density-bearing object works (e.g. a `Distributions.Geometric` or `Distributions.Poisson`); it
+should implement
+
+- `Random.rand(rng, dist)` for sampling
+- `DensityInterface.logdensityof(dist, k)` for inference
+"""
+function duration_distributions end
+
+"""
+    length(model)
+
+Return the number of states of `model` (any `AbstractHSMM`, including `AbstractHMM`).
+"""
+Base.length(model::AbstractHSMM) = length(initialization(model))
+
+"""
+    eltype(model, obs, control)
+
+Return a type that can accommodate forward-backward computations for `model` on observations similar to `obs`.
+
+It is typically a promotion between the element type of the initialization, the element type of the transition matrix, and the type of an observation logdensity evaluated at `obs`.
+"""
+function Base.eltype(model::AbstractHSMM, obs, control)
+    init_type = eltype(initialization(model))
+    trans_type = eltype(transition_matrix(model, control))
+    dist = obs_distributions(model, control)[1]
+    logdensity_type = typeof(logdensityof(dist, obs))
+    return promote_type(init_type, trans_type, logdensity_type)
+end
+
+"""
+    log_initialization(model)
+
+Return the vector of initial state log-probabilities for `model`.
+
+Falls back on `initialization`.
+"""
+log_initialization(model::AbstractHSMM) = elementwise_log(initialization(model))
+
+"""
+    log_transition_matrix(model)
+    log_transition_matrix(model, control)
+
+Return the matrix of state transition log-probabilities for `model` (possibly when `control` is applied).
+
+Falls back on `transition_matrix`.
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
+"""
+log_transition_matrix(model::AbstractHSMM) = elementwise_log(transition_matrix(model))
+
+function log_transition_matrix(model::AbstractHSMM, control)
+    return elementwise_log(transition_matrix(model, control))
+end
+
+## Fallbacks for no control
+
+transition_matrix(model::AbstractHSMM, ::Nothing) = transition_matrix(model)
+log_transition_matrix(model::AbstractHSMM, ::Nothing) = log_transition_matrix(model)
+obs_distributions(model::AbstractHSMM, ::Nothing) = obs_distributions(model)
+duration_distributions(model::AbstractHSMM, ::Nothing) = duration_distributions(model)
+
+## Prior
+
+"""
+    logdensityof(model)
+
+Return the prior loglikelihood associated with the parameters of `model`.
+"""
+DensityInterface.logdensityof(model::AbstractHSMM) = false
+
+## Sampling
+
+"""
+    rand([rng,] hsmm::AbstractHSMM, T)
+    rand([rng,] hsmm::AbstractHSMM, control_seq)
+
+Simulate `hsmm` for `T` time steps, or when the sequence `control_seq` is applied.
+
+Sojourn lengths are drawn from the model's duration distributions (via [`rand_duration`](@ref)), so
+consecutive timesteps share the same state until the sojourn elapses, after which a new state is
+drawn under the no-self-transition constraint.
+
+Return a named tuple `(; state_seq, obs_seq, duration_seq)`, where `duration_seq[t]` is the sojourn
+length originally sampled for the segment containing `t` (it may exceed the remaining horizon if the
+sequence was truncated at `T`).
+"""
+function Random.rand(rng::AbstractRNG, hsmm::AbstractHSMM, control_seq::AbstractVector)
+    T = length(control_seq)
+    N = length(hsmm)
+
+    init = initialization(hsmm)
+    dummy_log_probas = fill(-Inf, N)
+    current_state = rand(rng, LightCategorical(init, dummy_log_probas))
+
+    obs_dists1 = obs_distributions(hsmm, control_seq[1])
+    first_obs = rand(rng, obs_dists1[current_state])
+
+    state_seq = Vector{Int}(undef, T)
+    obs_seq = Vector{typeof(first_obs)}(undef, T)
+    duration_seq = Vector{Int}(undef, T)
+
+    t = 1
+    while t <= T
+        duration_dists = duration_distributions(hsmm, control_seq[t])
+        current_duration = rand_duration(rng, duration_dists[current_state])
+
+        end_time = min(t + current_duration - 1, T)
+        for τ in t:end_time
+            state_seq[τ] = current_state
+            duration_seq[τ] = current_duration
+            if τ == 1
+                obs_seq[τ] = first_obs
+            else
+                obs_dists = obs_distributions(hsmm, control_seq[τ])
+                obs_seq[τ] = rand(rng, obs_dists[current_state])
+            end
+        end
+
+        t = end_time + 1
+
+        if t <= T
+            # The control at time `t` drives the transition into time `t`.
+            trans = transition_matrix(hsmm, control_seq[t])
+            current_state = rand(
+                rng, LightCategorical(trans[current_state, :], dummy_log_probas)
+            )
+        end
+    end
+
+    return (; state_seq=state_seq, obs_seq=obs_seq, duration_seq=duration_seq)
+end
+
+function Random.rand(hsmm::AbstractHSMM, control_seq::AbstractVector)
+    return rand(default_rng(), hsmm, control_seq)
+end
+
+function Random.rand(rng::AbstractRNG, hsmm::AbstractHSMM, T::Integer)
+    return rand(rng, hsmm, Fill(nothing, T))
+end
+
+function Random.rand(hsmm::AbstractHSMM, T::Integer)
+    return rand(hsmm, Fill(nothing, T))
+end

--- a/src/types/abstract_hsmm.jl
+++ b/src/types/abstract_hsmm.jl
@@ -7,10 +7,6 @@ An `AbstractHSMM` explicitly models state durations through a per-state duration
 Sojourn lengths are drawn from those distributions, so self-transitions in the transition matrix
 are forbidden (the diagonal must be zero).
 
-[`AbstractHMM`](@ref) is a subtype of `AbstractHSMM`: every HMM is mathematically an HSMM whose
-sojourn lengths follow a geometric distribution encoded by the diagonal of the transition matrix.
-The interface defined here is inherited by `AbstractHMM`.
-
 # Interface
 
 To create your own subtype of `AbstractHSMM`, you need to implement the following methods:
@@ -26,47 +22,11 @@ To create your own subtype of `AbstractHSMM`, you need to implement the followin
 Any `AbstractHSMM` which satisfies the interface can be given to the following functions:
 
 - [`rand`](@ref)
-"""
-abstract type AbstractHSMM end
 
-@inline DensityInterface.DensityKind(::AbstractHSMM) = HasDensity()
+"""
+abstract type AbstractHSMM <: AbstractLatentStateModel end
 
 ## Interface
-
-"""
-    initialization(model)
-
-Return the vector of initial state probabilities for `model` (any `AbstractHSMM`, including
-`AbstractHMM` subtypes).
-"""
-function initialization end
-
-"""
-    transition_matrix(model)
-    transition_matrix(model, control)
-
-Return the matrix of state transition probabilities for `model` (possibly when `control` is applied).
-
-For an [`AbstractHSMM`](@ref) the diagonal of this matrix must be zero (no self-transitions).
-
-!!! note
-    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
-"""
-function transition_matrix end
-
-"""
-    obs_distributions(model)
-    obs_distributions(model, control)
-
-Return a vector of observation distributions, one for each state of `model` (possibly when `control` is applied).
-
-These distribution objects should implement
-
-- `Random.rand(rng, dist)` for sampling
-- `DensityInterface.logdensityof(dist, obs)` for inference
-- `StatsAPI.fit!(dist, obs_seq, weight_seq)` for learning
-"""
-function obs_distributions end
 
 """
     duration_distributions(model)
@@ -85,93 +45,26 @@ should implement
 """
 function duration_distributions end
 
-"""
-    length(model)
+duration_distributions(model::AbstractHSMM, ::Nothing) = duration_distributions(model)
 
-Return the number of states of `model` (any `AbstractHSMM`, including `AbstractHMM`).
-"""
-Base.length(model::AbstractHSMM) = length(initialization(model))
-
-#= 
-We split out the the type handling for duration logdensities, since HMMs don't have 
-duration distributions. This allows [`AbstractHMM`](@ref) to inherit the `eltype`
-method defined here.
+#=
+We split out the type handling for duration logdensities so that the shared `eltype` promotion
+defined on `AbstractLatentStateModel` can be reused by both HMMs and HSMMs, with only the
+HSMM branch folding in the duration term.
 =#
 function duration_logdensity_type(model::AbstractHSMM, control)
     dist = duration_distributions(model, control)[1]
     return typeof(duration_logdensityof(dist, 1))
 end
 
-"""
-    eltype(model, obs, control)
-
-Return a type that can accommodate forward-backward computations for `model` on observations similar to `obs`.
-
-It is typically a promotion between the element type of the initialization, the element type of the transition matrix, and the type of an observation logdensity evaluated at `obs`.
-"""
-function Base.eltype(model::AbstractHSMM, obs, control)
-    init_type = eltype(initialization(model))
-    trans_type = eltype(transition_matrix(model, control))
-    dist = obs_distributions(model, control)[1]
-    logdensity_type = typeof(logdensityof(dist, obs))
-    return promote_type(
-        init_type, trans_type, logdensity_type, duration_logdensity_type(model, control)
-    )
-end
-
-"""
-    log_initialization(model)
-
-Return the vector of initial state log-probabilities for `model`.
-
-Falls back on `initialization`.
-"""
-log_initialization(model::AbstractHSMM) = elementwise_log(initialization(model))
-
-"""
-    log_transition_matrix(model)
-    log_transition_matrix(model, control)
-
-Return the matrix of state transition log-probabilities for `model` (possibly when `control` is applied).
-
-Falls back on `transition_matrix`.
-
-!!! note
-    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
-"""
-log_transition_matrix(model::AbstractHSMM) = elementwise_log(transition_matrix(model))
-
-function log_transition_matrix(model::AbstractHSMM, control)
-    return elementwise_log(transition_matrix(model, control))
-end
-
-## Fallbacks for no control
-
-transition_matrix(model::AbstractHSMM, ::Nothing) = transition_matrix(model)
-log_transition_matrix(model::AbstractHSMM, ::Nothing) = log_transition_matrix(model)
-obs_distributions(model::AbstractHSMM, ::Nothing) = obs_distributions(model)
-duration_distributions(model::AbstractHSMM, ::Nothing) = duration_distributions(model)
-
-## Prior
-
-"""
-    logdensityof(model)
-
-Return the prior loglikelihood associated with the parameters of `model`.
-"""
-DensityInterface.logdensityof(model::AbstractHSMM) = false
-
-## Fill logdensities
-
-function obs_logdensities!(
-    logb::AbstractVector{T}, hmm::AbstractHSMM, obs, control; error_if_not_finite::Bool=true
-) where {T}
-    dists = obs_distributions(hmm, control)
-    @simd for i in eachindex(logb, dists)
-        logb[i] = logdensityof(dists[i], obs)
-    end
-    error_if_not_finite && @argcheck maximum(logb) < typemax(T)
-    return nothing
+#=
+Extend the shared `eltype` (which promotes the initialization, transition and observation
+logdensity types) with the duration logdensity type, since HSMM forward-backward also accumulates
+duration terms.
+=#
+function Base.eltype(hsmm::AbstractHSMM, obs, control)
+    base_type = @invoke Base.eltype(hsmm::AbstractLatentStateModel, obs, control)
+    return promote_type(base_type, duration_logdensity_type(hsmm, control))
 end
 
 ## Sampling
@@ -234,16 +127,4 @@ function Random.rand(rng::AbstractRNG, hsmm::AbstractHSMM, control_seq::Abstract
     end
 
     return (; state_seq=state_seq, obs_seq=obs_seq, duration_seq=duration_seq)
-end
-
-function Random.rand(hsmm::AbstractHSMM, control_seq::AbstractVector)
-    return rand(default_rng(), hsmm, control_seq)
-end
-
-function Random.rand(rng::AbstractRNG, hsmm::AbstractHSMM, T::Integer)
-    return rand(rng, hsmm, Fill(nothing, T))
-end
-
-function Random.rand(hsmm::AbstractHSMM, T::Integer)
-    return rand(hsmm, Fill(nothing, T))
 end

--- a/src/types/abstract_latent_state_model.jl
+++ b/src/types/abstract_latent_state_model.jl
@@ -1,0 +1,156 @@
+"""
+    AbstractLatentStateModel
+
+Abstract supertype for a discrete-latent-state sequence model amenable to simulation, inference
+and learning.
+
+This type factors out the methods shared by [`AbstractHMM`](@ref) and [`AbstractHSMM`](@ref)
+(state initialization, transition matrix, observation distributions, and the derived `length`,
+`eltype`, log-accessors and no-control fallbacks). 
+# Interface
+
+Every subtype must implement:
+
+- [`initialization`](@ref)
+- [`transition_matrix`](@ref)
+- [`obs_distributions`](@ref)
+- [`fit!`](@ref) (for learning)
+
+Subtypes may add further requirements (e.g. [`AbstractHSMM`](@ref) additionally requires
+[`duration_distributions`](@ref)).
+"""
+abstract type AbstractLatentStateModel end
+
+@inline DensityInterface.DensityKind(::AbstractLatentStateModel) = HasDensity()
+
+## Interface
+
+"""
+    initialization(model)
+
+Return the vector of initial state probabilities for `model` (any `AbstractLatentStateModel`).
+"""
+function initialization end
+
+"""
+    transition_matrix(model)
+    transition_matrix(model, control)
+
+Return the matrix of state transition probabilities for `model` (possibly when `control` is applied).
+
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
+"""
+function transition_matrix end
+
+"""
+    obs_distributions(model)
+    obs_distributions(model, control)
+
+Return a vector of observation distributions, one for each state of `model` (possibly when `control` is applied).
+
+These distribution objects should implement
+
+- `Random.rand(rng, dist)` for sampling
+- `DensityInterface.logdensityof(dist, obs)` for inference
+- `StatsAPI.fit!(dist, obs_seq, weight_seq)` for learning
+"""
+function obs_distributions end
+
+"""
+    length(model)
+
+Return the number of states of `model` (any `AbstractLatentStateModel`).
+"""
+Base.length(model::AbstractLatentStateModel) = length(initialization(model))
+
+"""
+    eltype(model, obs, control)
+
+Return a type that can accommodate forward-backward computations for `model` on observations similar to `obs`.
+
+It is typically a promotion between the element type of the initialization, the element type of the transition matrix, and the type of an observation logdensity evaluated at `obs`. Subtypes that carry additional numeric ingredients extend this promotion (e.g. [`AbstractHSMM`](@ref) folds in the duration logdensity type).
+"""
+function Base.eltype(model::AbstractLatentStateModel, obs, control)
+    init_type = eltype(initialization(model))
+    trans_type = eltype(transition_matrix(model, control))
+    dist = obs_distributions(model, control)[1]
+    logdensity_type = typeof(logdensityof(dist, obs))
+    return promote_type(init_type, trans_type, logdensity_type)
+end
+
+"""
+    log_initialization(model)
+
+Return the vector of initial state log-probabilities for `model`.
+
+Falls back on `initialization`.
+"""
+log_initialization(model::AbstractLatentStateModel) = elementwise_log(initialization(model))
+
+"""
+    log_transition_matrix(model)
+    log_transition_matrix(model, control)
+
+Return the matrix of state transition log-probabilities for `model` (possibly when `control` is applied).
+
+Falls back on `transition_matrix`.
+
+!!! note
+    When processing sequences, the control at time `t` influences the transition from time `t-1` to `t` (since version 0.7 of the package).
+"""
+log_transition_matrix(model::AbstractLatentStateModel) =
+    elementwise_log(transition_matrix(model))
+
+function log_transition_matrix(model::AbstractLatentStateModel, control)
+    return elementwise_log(transition_matrix(model, control))
+end
+
+## Fallbacks for no control
+
+transition_matrix(model::AbstractLatentStateModel, ::Nothing) = transition_matrix(model)
+function log_transition_matrix(model::AbstractLatentStateModel, ::Nothing)
+    return log_transition_matrix(model)
+end
+obs_distributions(model::AbstractLatentStateModel, ::Nothing) = obs_distributions(model)
+
+## Prior
+
+"""
+    logdensityof(model)
+
+Return the prior loglikelihood associated with the parameters of `model`.
+"""
+DensityInterface.logdensityof(model::AbstractLatentStateModel) = false
+
+## Fill logdensities
+
+function obs_logdensities!(
+    logb::AbstractVector{T},
+    model::AbstractLatentStateModel,
+    obs,
+    control;
+    error_if_not_finite::Bool=true,
+) where {T}
+    dists = obs_distributions(model, control)
+    @simd for i in eachindex(logb, dists)
+        logb[i] = logdensityof(dists[i], obs)
+    end
+    error_if_not_finite && @argcheck maximum(logb) < typemax(T)
+    return nothing
+end
+
+## Sampling entry points shared across latent-state models
+
+function Random.rand(model::AbstractLatentStateModel, control_seq::AbstractVector)
+    return rand(default_rng(), model, control_seq)
+end
+
+function Random.rand(rng::AbstractRNG, model::AbstractLatentStateModel, T::Integer)
+    return rand(rng, model, Fill(nothing, T))
+end
+
+function Random.rand(model::AbstractLatentStateModel, T::Integer)
+    return rand(model, Fill(nothing, T))
+end

--- a/src/types/hsmm.jl
+++ b/src/types/hsmm.jl
@@ -1,0 +1,66 @@
+"""
+$(TYPEDEF)
+
+Basic implementation of an HSMM with explicit state durations.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct HSMM{
+    V<:AbstractVector,
+    M<:AbstractMatrix,
+    VD<:AbstractVector,
+    VDur<:AbstractVector,
+    Vl<:AbstractVector,
+    Ml<:AbstractMatrix,
+} <: AbstractHSMM
+    "initial state probabilities"
+    init::V
+    "state transition probabilities (zero diagonal, no self-transitions)"
+    trans::M
+    "observation distributions"
+    dists::VD
+    "state duration distributions, interpreted as the law of `(sojourn - 1)`"
+    dur_dists::VDur
+    "logarithms of initial state probabilities"
+    loginit::Vl
+    "logarithms of state transition probabilities"
+    logtrans::Ml
+
+    function HSMM(
+        init::AbstractVector,
+        trans::AbstractMatrix,
+        dists::AbstractVector,
+        dur_dists::AbstractVector,
+    )
+        log_init = elementwise_log(init)
+        log_trans = elementwise_log(trans)
+        hsmm = new{
+            typeof(init),
+            typeof(trans),
+            typeof(dists),
+            typeof(dur_dists),
+            typeof(log_init),
+            typeof(log_trans),
+        }(
+            init, trans, dists, dur_dists, log_init, log_trans
+        )
+        @argcheck valid_hsmm(hsmm)
+        return hsmm
+    end
+end
+
+function Base.show(io::IO, hsmm::HSMM)
+    return print(
+        io,
+        "Hidden Semi-Markov Model with:\n - initialization: $(hsmm.init)\n - transition matrix: $(hsmm.trans)\n - observation distributions: [$(join(hsmm.dists, ", "))]\n - duration distributions: [$(join(hsmm.dur_dists, ", "))]",
+    )
+end
+
+initialization(hsmm::HSMM) = hsmm.init
+log_initialization(hsmm::HSMM) = hsmm.loginit
+transition_matrix(hsmm::HSMM) = hsmm.trans
+log_transition_matrix(hsmm::HSMM) = hsmm.logtrans
+obs_distributions(hsmm::HSMM) = hsmm.dists
+duration_distributions(hsmm::HSMM) = hsmm.dur_dists

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -58,7 +58,7 @@ function valid_hsmm(hsmm::AbstractHSMM, control=nothing)
     length(durations) == N || return false
 
     # No self-transitions (allowing for numerical noise).
-    all(<=(eps(eltype(trans))), diag(trans)) || return false
+    all(<=(eps(eltype(trans))), Diagonal(trans)) || return false
 
     # Duration distributions must carry a density.
     return valid_dists(durations)

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -20,7 +20,7 @@ end
 
 Perform some checks to rule out obvious inconsistencies with an `AbstractHMM` object.
 """
-function valid_hmm(hmm::AbstractHMM, control=nothing)
+function valid_hmm(hmm::AbstractHSMM, control=nothing)
     init = initialization(hmm)
     trans = transition_matrix(hmm, control)
     dists = obs_distributions(hmm, control)
@@ -34,4 +34,36 @@ function valid_hmm(hmm::AbstractHMM, control=nothing)
         return false
     end
     return true
+end
+
+"""
+    valid_hsmm(hsmm, control=nothing)
+
+Perform some checks to rule out obvious inconsistencies with an `AbstractHSMM` object.
+
+On top of the [`valid_hmm`](@ref)-style checks (probability initialization, stochastic transition
+matrix, matching dimensions, density-bearing observation distributions), this verifies:
+
+- the transition matrix has a zero diagonal (no self-transitions);
+- there is one density-bearing duration distribution per state.
+"""
+function valid_hsmm(hsmm::AbstractHSMM, control=nothing)
+    valid_hmm(hsmm, control) || return false
+
+    trans = transition_matrix(hsmm, control)
+    durations = duration_distributions(hsmm, control)
+    N = length(hsmm)
+
+    # One duration distribution per state.
+    length(durations) == N || return false
+
+    # No self-transitions (allowing for numerical noise).
+    for i in 1:N
+        if trans[i, i] > 1e-10
+            return false
+        end
+    end
+
+    # Duration distributions must carry a density.
+    return valid_dists(durations)
 end

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -19,8 +19,12 @@ end
     valid_hmm(hmm)
 
 Perform some checks to rule out obvious inconsistencies with an `AbstractHMM` object.
+
+Dispatches on [`AbstractLatentStateModel`](@ref) so the same structural checks (probability
+initialization, stochastic transition matrix, matching dimensions, density-bearing observation
+distributions) back both [`valid_hmm`](@ref) and [`valid_hsmm`](@ref).
 """
-function valid_hmm(hmm::AbstractHSMM, control=nothing)
+function valid_hmm(hmm::AbstractLatentStateModel, control=nothing)
     init = initialization(hmm)
     trans = transition_matrix(hmm, control)
     dists = obs_distributions(hmm, control)

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -58,11 +58,7 @@ function valid_hsmm(hsmm::AbstractHSMM, control=nothing)
     length(durations) == N || return false
 
     # No self-transitions (allowing for numerical noise).
-    for i in 1:N
-        if trans[i, i] > 1e-10
-            return false
-        end
-    end
+    all(<=(eps(eltype(trans))), diag(trans)) || return false
 
     # Duration distributions must carry a density.
     return valid_dists(durations)

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -3,6 +3,7 @@ using HiddenMarkovModels
 using HiddenMarkovModels:
     AbstractHSMM,
     duration_distributions,
+    duration_logdensity_type,
     elementwise_log,
     log_initialization,
     log_transition_matrix,
@@ -70,6 +71,48 @@ end
         (; state_seq, duration_seq) = rand(StableRNG(11), hsmm, 100)
         @test all(duration_seq .== 1)
         @test all(state_seq[t] != state_seq[t + 1] for t in 1:99)
+    end
+end
+
+@testset "duration_logdensity_type" begin
+    init = [0.6, 0.4]
+    trans = [0.0 1.0; 1.0 0.0]
+    dists = [Normal(0.0, 1.0), Normal(5.0, 1.0)]
+
+    @testset "HSMM returns the duration logdensity type" begin
+        hsmm = HSMM(init, trans, dists, [Geometric(0.4), Geometric(0.6)])
+        @test duration_logdensity_type(hsmm, nothing) === Float64
+
+        hsmm32 = HSMM(init, trans, dists, [Geometric(0.4f0), Geometric(0.6f0)])
+        @test duration_logdensity_type(hsmm32, nothing) === Float32
+    end
+
+    @testset "Feeds into eltype promotion" begin
+        #=
+        Everything is Float32 except the duration logdensities, which must drive the
+        promotion up to Float64.
+        =#
+        init32 = Float32[0.6, 0.4]
+        trans32 = Float32[0.0 1.0; 1.0 0.0]
+        dists32 = [Normal(0.0f0, 1.0f0), Normal(5.0f0, 1.0f0)]
+        hsmm = HSMM(init32, trans32, dists32, [Geometric(0.4), Geometric(0.6)])
+        @test eltype(hsmm, 0.0f0, nothing) === Float64
+    end
+
+    @testset "HMM no-op returns Union{}" begin
+        hmm = HMM([0.5, 0.5], [0.7 0.3; 0.2 0.8], dists)
+        @test duration_logdensity_type(hmm, nothing) === Union{}
+        #=
+        Union{} is the neutral element of promote_type, so the HMM eltype is
+        unaffected by the HSMM machinery.
+        =#
+        @test eltype(hmm, 0.0, nothing) === Float64
+        hmm32 = HMM(
+            Float32[0.5, 0.5],
+            Float32[0.7 0.3; 0.2 0.8],
+            [Normal(0.0f0, 1.0f0), Normal(5.0f0, 1.0f0)],
+        )
+        @test eltype(hmm32, 0.0f0, nothing) === Float32
     end
 end
 

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -1,5 +1,12 @@
+using DensityInterface: DensityKind, HasDensity
 using HiddenMarkovModels
-using HiddenMarkovModels: AbstractHSMM, duration_distributions, valid_hsmm
+using HiddenMarkovModels:
+    AbstractHSMM,
+    duration_distributions,
+    elementwise_log,
+    log_initialization,
+    log_transition_matrix,
+    valid_hsmm
 using Distributions: Geometric, Normal
 using StableRNGs: StableRNG
 using Test
@@ -20,6 +27,9 @@ using Test
         @test obs_distributions(hsmm) === dists
         @test duration_distributions(hsmm) === dur_dists
         @test valid_hsmm(hsmm)
+        @test log_initialization(hsmm) == elementwise_log(init)
+        @test log_transition_matrix(hsmm) == elementwise_log(trans)
+        @test DensityKind(hsmm) == HasDensity()
     end
 
     @testset "Constructor rejects self-transitions (no silent zeroing)" begin

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -1,0 +1,91 @@
+using HiddenMarkovModels
+using HiddenMarkovModels: AbstractHSMM, duration_distributions, valid_hsmm
+using Distributions: Geometric, Normal
+using StableRNGs: StableRNG
+using Test
+
+@testset "HSMM type" begin
+    init = [0.6, 0.4]
+    trans = [0.0 1.0; 1.0 0.0]
+    dists = [Normal(0.0, 1.0), Normal(5.0, 1.0)]
+    dur_dists = [Geometric(0.4), Geometric(0.6)]
+
+    @testset "Construction and accessors" begin
+        hsmm = HSMM(init, trans, dists, dur_dists)
+        @test hsmm isa AbstractHSMM
+        @test !(hsmm isa AbstractHMM)
+        @test length(hsmm) == 2
+        @test initialization(hsmm) == init
+        @test transition_matrix(hsmm) == trans
+        @test obs_distributions(hsmm) === dists
+        @test duration_distributions(hsmm) === dur_dists
+        @test valid_hsmm(hsmm)
+    end
+
+    @testset "Constructor rejects self-transitions (no silent zeroing)" begin
+        bad_trans = [0.1 0.9; 1.0 0.0]
+        @test_throws ArgumentError HSMM(init, bad_trans, dists, dur_dists)
+    end
+
+    @testset "Constructor rejects dimension mismatch" begin
+        @test_throws ArgumentError HSMM(init, trans, dists, dur_dists[1:1])
+        @test_throws ArgumentError HSMM([1.0], trans, dists, dur_dists)
+    end
+end
+
+@testset "HSMM sampling" begin
+    init = [1.0, 0.0, 0.0]
+    trans = [0.0 0.5 0.5; 0.5 0.0 0.5; 0.5 0.5 0.0]
+    dists = [Normal(0.0), Normal(5.0), Normal(10.0)]
+
+    @testset "Return shape and bounds" begin
+        dur_dists = [Geometric(0.3) for _ in 1:3]
+        hsmm = HSMM(init, trans, dists, dur_dists)
+        T = 200
+        (; state_seq, obs_seq, duration_seq) = rand(StableRNG(7), hsmm, T)
+        @test length(state_seq) == T
+        @test length(obs_seq) == T
+        @test length(duration_seq) == T
+        @test all(s in 1:3 for s in state_seq)
+        @test all(d >= 1 for d in duration_seq)
+        @test state_seq[1] == 1  # init forces state 1
+        @test eltype(obs_seq) == Float64
+    end
+
+    @testset "Unit sojourns forbid consecutive repeats" begin
+        # Geometric(1.0) => the (sojourn-1) law is a point mass at 0, so every sojourn has length
+        # 1; with a zero-diagonal transition matrix no two consecutive timesteps share a state.
+        dur_dists = [Geometric(1.0) for _ in 1:3]
+        hsmm = HSMM(init, trans, dists, dur_dists)
+        (; state_seq, duration_seq) = rand(StableRNG(11), hsmm, 100)
+        @test all(duration_seq .== 1)
+        @test all(state_seq[t] != state_seq[t + 1] for t in 1:99)
+    end
+end
+
+@testset "AbstractHMM <: AbstractHSMM" begin
+    init = [0.5, 0.5]
+    trans = [0.7 0.3; 0.2 0.8]
+    dists = [Normal(0.0), Normal(5.0)]
+    hmm = HMM(init, trans, dists)
+
+    @testset "Subtype relationship" begin
+        @test HMM <: AbstractHMM
+        @test AbstractHMM <: AbstractHSMM
+        @test hmm isa AbstractHSMM
+    end
+
+    @testset "HMM does not gain a duration_distributions method" begin
+        # An HMM is structurally an AbstractHSMM for code reuse, but it deliberately has no
+        # duration distributions: regular HMM usage is unaffected by the HSMM machinery.
+        @test !hasmethod(duration_distributions, Tuple{typeof(hmm)})
+    end
+
+    @testset "HMM rand keeps 2-tuple shape (backward compatible)" begin
+        out = rand(StableRNG(5), hmm, 50)
+        @test propertynames(out) == (:state_seq, :obs_seq)
+        @test !hasproperty(out, :duration_seq)
+        @test length(out.state_seq) == 50
+        @test length(out.obs_seq) == 50
+    end
+end

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -1,6 +1,7 @@
 using DensityInterface: DensityKind, HasDensity
 using HiddenMarkovModels
 using HiddenMarkovModels:
+    AbstractLatentStateModel,
     AbstractHSMM,
     duration_distributions,
     duration_logdensity_type,
@@ -99,13 +100,9 @@ end
         @test eltype(hsmm, 0.0f0, nothing) === Float64
     end
 
-    @testset "HMM no-op returns Union{}" begin
+    @testset "HMM eltype ignores duration machinery" begin
         hmm = HMM([0.5, 0.5], [0.7 0.3; 0.2 0.8], dists)
-        @test duration_logdensity_type(hmm, nothing) === Union{}
-        #=
-        Union{} is the neutral element of promote_type, so the HMM eltype is
-        unaffected by the HSMM machinery.
-        =#
+        @test !hasmethod(duration_logdensity_type, Tuple{typeof(hmm),Nothing})
         @test eltype(hmm, 0.0, nothing) === Float64
         hmm32 = HMM(
             Float32[0.5, 0.5],
@@ -116,21 +113,23 @@ end
     end
 end
 
-@testset "AbstractHMM <: AbstractHSMM" begin
+@testset "Type hierarchy: AbstractHMM and AbstractHSMM are siblings" begin
     init = [0.5, 0.5]
     trans = [0.7 0.3; 0.2 0.8]
     dists = [Normal(0.0), Normal(5.0)]
     hmm = HMM(init, trans, dists)
 
-    @testset "Subtype relationship" begin
+    @testset "Sibling relationship under AbstractLatentStateModel" begin
         @test HMM <: AbstractHMM
-        @test AbstractHMM <: AbstractHSMM
-        @test hmm isa AbstractHSMM
+        @test AbstractHMM <: AbstractLatentStateModel
+        @test AbstractHSMM <: AbstractLatentStateModel
+        @test !(AbstractHMM <: AbstractHSMM)
+        @test !(AbstractHSMM <: AbstractHMM)
+        @test hmm isa AbstractLatentStateModel
+        @test !(hmm isa AbstractHSMM)
     end
 
     @testset "HMM does not gain a duration_distributions method" begin
-        # An HMM is structurally an AbstractHSMM for code reuse, but it deliberately has no
-        # duration distributions: regular HMM usage is unaffected by the HSMM machinery.
         @test !hasmethod(duration_distributions, Tuple{typeof(hmm)})
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,4 +80,8 @@ end
     @testset verbose = true "Duration convention" begin
         include("duration.jl")
     end
+
+    @testset verbose = true "HSMM types and sampling" begin
+        include("hsmm.jl")
+    end
 end


### PR DESCRIPTION
Second step in porting Hidden Semi-Markov Models into the package. This PR adds the `HSMM` type layer and sampling only. Unifies the abstract-type hierarchy so `AbstractHMM <: AbstractHSMM`, introduces the concrete `HSMM` type, and implements duration-aware `rand`. 