### PR TITLE
Fixes JET throwing on ControlledEmission methods

### DIFF
--- a/src/types/controlled_emission_hmm.jl
+++ b/src/types/controlled_emission_hmm.jl
@@ -19,20 +19,6 @@ abstract type ControlledEmission end
 
 DensityInterface.DensityKind(::ControlledEmission) = HasDensity()
 
-# Required-interface fallbacks for the control-aware methods. Concrete subtypes must override
-# these; the abstract methods make the interface complete for static analysis (a missing
-# implementation is reached through `ControlBoundEmission`) and throw a `MethodError` whose display
-# is augmented by an error hint (see `__init__`). No `rand` fallback is defined: a generic
-# `rand(::AbstractRNG, ::ControlledEmission, control)` would be ambiguous with Base's
-# `rand(rng, X, dims::Integer...)`, and Base already satisfies static analysis for that call.
-function DensityInterface.logdensityof(d::ControlledEmission, obs, control)
-    return throw(MethodError(logdensityof, (d, obs, control)))
-end
-
-function StatsAPI.fit!(d::ControlledEmission, obs_seq, control_seq, weights)
-    return throw(MethodError(fit!, (d, obs_seq, control_seq, weights)))
-end
-
 """
 $(TYPEDEF)
 
@@ -285,34 +271,6 @@ function __init__()
                 io,
                 "\nHint: `ControlledEmissionHMM` requires `control_seq`. " *
                 "Call `fit!(hmm, fb_storage, obs_seq, control_seq; seq_ends=...)` instead.",
-            )
-
-        elseif exc.f === logdensityof &&
-            length(argtypes) == 3 &&
-            argtypes[1] <: ControlledEmission
-            print(
-                io,
-                "\nHint: the emission type `$(argtypes[1])` <: ControlledEmission must implement " *
-                "`DensityInterface.logdensityof(dist, obs, control)`.",
-            )
-
-        elseif exc.f === rand &&
-            length(argtypes) == 3 &&
-            argtypes[1] <: AbstractRNG &&
-            argtypes[2] <: ControlledEmission
-            print(
-                io,
-                "\nHint: the emission type `$(argtypes[2])` <: ControlledEmission must implement " *
-                "`Random.rand(rng, dist, control)`.",
-            )
-
-        elseif exc.f === StatsAPI.fit! &&
-            length(argtypes) == 4 &&
-            argtypes[1] <: ControlledEmission
-            print(
-                io,
-                "\nHint: the emission type `$(argtypes[1])` <: ControlledEmission must implement " *
-                "`StatsAPI.fit!(dist, obs_seq, control_seq, weights)`.",
             )
         end
     end

--- a/src/types/controlled_emission_hmm.jl
+++ b/src/types/controlled_emission_hmm.jl
@@ -19,13 +19,14 @@ abstract type ControlledEmission end
 
 DensityInterface.DensityKind(::ControlledEmission) = HasDensity()
 
-# Required interface fallbacks
+# Required-interface fallbacks for the control-aware methods. Concrete subtypes must override
+# these; the abstract methods make the interface complete for static analysis (a missing
+# implementation is reached through `ControlBoundEmission`) and throw a `MethodError` whose display
+# is augmented by an error hint (see `__init__`). No `rand` fallback is defined: a generic
+# `rand(::AbstractRNG, ::ControlledEmission, control)` would be ambiguous with Base's
+# `rand(rng, X, dims::Integer...)`, and Base already satisfies static analysis for that call.
 function DensityInterface.logdensityof(d::ControlledEmission, obs, control)
     return throw(MethodError(logdensityof, (d, obs, control)))
-end
-
-function Random.rand(rng::AbstractRNG, d::ControlledEmission, control)
-    return throw(MethodError(rand, (rng, d, control)))
 end
 
 function StatsAPI.fit!(d::ControlledEmission, obs_seq, control_seq, weights)
@@ -284,6 +285,34 @@ function __init__()
                 io,
                 "\nHint: `ControlledEmissionHMM` requires `control_seq`. " *
                 "Call `fit!(hmm, fb_storage, obs_seq, control_seq; seq_ends=...)` instead.",
+            )
+
+        elseif exc.f === logdensityof &&
+            length(argtypes) == 3 &&
+            argtypes[1] <: ControlledEmission
+            print(
+                io,
+                "\nHint: the emission type `$(argtypes[1])` <: ControlledEmission must implement " *
+                "`DensityInterface.logdensityof(dist, obs, control)`.",
+            )
+
+        elseif exc.f === rand &&
+            length(argtypes) == 3 &&
+            argtypes[1] <: AbstractRNG &&
+            argtypes[2] <: ControlledEmission
+            print(
+                io,
+                "\nHint: the emission type `$(argtypes[2])` <: ControlledEmission must implement " *
+                "`Random.rand(rng, dist, control)`.",
+            )
+
+        elseif exc.f === StatsAPI.fit! &&
+            length(argtypes) == 4 &&
+            argtypes[1] <: ControlledEmission
+            print(
+                io,
+                "\nHint: the emission type `$(argtypes[1])` <: ControlledEmission must implement " *
+                "`StatsAPI.fit!(dist, obs_seq, control_seq, weights)`.",
             )
         end
     end

--- a/src/types/controlled_emission_hmm.jl
+++ b/src/types/controlled_emission_hmm.jl
@@ -19,6 +19,19 @@ abstract type ControlledEmission end
 
 DensityInterface.DensityKind(::ControlledEmission) = HasDensity()
 
+# Required interface fallbacks
+function DensityInterface.logdensityof(d::ControlledEmission, obs, control)
+    return throw(MethodError(logdensityof, (d, obs, control)))
+end
+
+function Random.rand(rng::AbstractRNG, d::ControlledEmission, control)
+    return throw(MethodError(rand, (rng, d, control)))
+end
+
+function StatsAPI.fit!(d::ControlledEmission, obs_seq, control_seq, weights)
+    return throw(MethodError(fit!, (d, obs_seq, control_seq, weights)))
+end
+
 """
 $(TYPEDEF)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -9,14 +9,6 @@ using Random: Random, AbstractRNG, Xoshiro
 using Test
 using Test: TestLogger
 
-struct TestControlledEmissionDist <: ControlledEmission end
-
-# `DensityKind` is inherited from the `ControlledEmission` abstract supertype.
-function DensityInterface.logdensityof(::TestControlledEmissionDist, obs, control)
-    return -(obs - control)^2
-end
-Random.rand(::AbstractRNG, ::TestControlledEmissionDist, control) = control
-
 function thrown_error(f)
     try
         f()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using Literate
 using Pkg
 using Test
 
+include("utils.jl")
+
 TEST_SUITE = get(ENV, "JULIA_HMM_TEST_SUITE", "Standard")
 if TEST_SUITE == "HMMBase"
     Pkg.add("HMMBase")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,10 @@
+using DensityInterface
+using Random: Random, AbstractRNG
+# defined separately so we can import in `runtests.jl` so JET sees a concrete ControlledEmission subtype.
+struct TestControlledEmissionDist <: ControlledEmission end
+
+# `DensityKind` is inherited from the `ControlledEmission` abstract supertype.
+function DensityInterface.logdensityof(::TestControlledEmissionDist, obs, control)
+    return -(obs - control)^2
+end
+Random.rand(::AbstractRNG, ::TestControlledEmissionDist, control) = control


### PR DESCRIPTION
~Adds three fallbacks so JET is happy. This does fix the problem, but maybe there is a better way?~

This PR now moves the dummy `ControlledEmission` subtype into a `utils.jl` file and imports it in `runtest.jl` so JET can see it. Resolves #165 