### PR TITLE
Add HSMM `joint_logdensityof` and `duration_logsurvival`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -118,6 +118,7 @@ HiddenMarkovModels.ControlBoundEmission
 HiddenMarkovModels.ControlBoundEmissionVector
 HiddenMarkovModels.duration_logdensityof
 HiddenMarkovModels.rand_duration
+HiddenMarkovModels.duration_logsurvival
 HiddenMarkovModels.AbstractLatentStateModel
 HiddenMarkovModels.AbstractHSMM
 HiddenMarkovModels.HSMM

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -119,6 +119,7 @@ HiddenMarkovModels.ControlBoundEmissionVector
 HiddenMarkovModels.duration_logdensityof
 HiddenMarkovModels.rand_duration
 HiddenMarkovModels.duration_logsurvival
+HiddenMarkovModels.StateSegments
 HiddenMarkovModels.AbstractLatentStateModel
 HiddenMarkovModels.AbstractHSMM
 HiddenMarkovModels.HSMM

--- a/ext/HiddenMarkovModelsDistributionsExt.jl
+++ b/ext/HiddenMarkovModelsDistributionsExt.jl
@@ -7,6 +7,8 @@ using Distributions:
     UnivariateDistribution,
     MultivariateDistribution,
     MatrixDistribution,
+    DiscreteUnivariateDistribution,
+    logccdf,
     fit
 
 function HiddenMarkovModels.fit_in_sequence!(
@@ -42,5 +44,14 @@ end
 
 dcat(M1, M2) = cat(M1, M2; dims=3)
 =#
+
+# Duration distributions model `sojourn - 1`, so `P(sojourn >= k) = P(dist > k - 2)`.
+function HiddenMarkovModels.duration_logsurvival(
+    dist::DiscreteUnivariateDistribution, k::Integer
+)
+    # `logccdf` can return `NaN` at the lower boundary.
+    k <= one(k) && return zero(logccdf(dist, k))
+    return logccdf(dist, k - 2)
+end
 
 end

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -21,7 +21,7 @@ using ProgressLogging: @withprogress, @logprogress
 using Random: Random, AbstractRNG, default_rng
 using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange, rowvals
 using StatsAPI: StatsAPI, fit, fit!
-using StatsFuns: log2π
+using StatsFuns: log2π, log1mexp, logaddexp
 
 export AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
 export ControlledEmission, ControlBoundEmission, ControlBoundEmissionVector

--- a/src/HiddenMarkovModels.jl
+++ b/src/HiddenMarkovModels.jl
@@ -21,7 +21,7 @@ using ProgressLogging: @withprogress, @logprogress
 using Random: Random, AbstractRNG, default_rng
 using SparseArrays: AbstractSparseArray, SparseMatrixCSC, nonzeros, nnz, nzrange, rowvals
 using StatsAPI: StatsAPI, fit, fit!
-using StatsFuns: log2π, log1mexp, logaddexp
+using StatsFuns: log2π
 
 export AbstractHSMM, HSMM, AbstractHMM, HMM, ControlledEmissionHMM
 export ControlledEmission, ControlBoundEmission, ControlBoundEmissionVector
@@ -41,6 +41,7 @@ include("utils/fit.jl")
 include("utils/lightdiagnormal.jl")
 include("utils/lightcategorical.jl")
 include("utils/limits.jl")
+include("utils/segments.jl")
 include("utils/duration.jl")
 
 include("inference/predict.jl")

--- a/src/inference/logdensity.jl
+++ b/src/inference/logdensity.jl
@@ -45,3 +45,58 @@ function joint_logdensityof(
     end
     return logL
 end
+
+"""
+$(SIGNATURES)
+
+Compute the joint loglikelihood of `obs_seq` and `state_seq` for `hsmm`.
+
+Each constant-state segment contributes its sojourn length to its duration distribution. The
+control at the segment's first timestep determines both its duration distribution and the
+transition into it.
+
+The final segment is right-censored and therefore contributes duration_logsurvival
+rather than duration_logdensityof.
+"""
+function joint_logdensityof(
+    hsmm::AbstractHSMM,
+    obs_seq::AbstractVector,
+    state_seq::AbstractVector,
+    control_seq::AbstractVector=Fill(nothing, length(obs_seq));
+    seq_ends::AbstractVectorOrNTuple{Int}=(length(obs_seq),),
+)
+    R = eltype(hsmm, obs_seq[1], control_seq[1])
+    logL = zero(R)
+    for k in eachindex(seq_ends)
+        t1, t2 = seq_limits(seq_ends, k)
+        # Initialization
+        init = initialization(hsmm)
+        logL += log(init[state_seq[t1]])
+        # Observations
+        for t in t1:t2
+            dists = obs_distributions(hsmm, control_seq[t])
+            logL += logdensityof(dists[state_seq[t]], obs_seq[t])
+        end
+        # Durations and transitions, segment by segment
+        t_start = t1
+        while t_start <= t2
+            t_end = t_start
+            while t_end < t2 && state_seq[t_end + 1] == state_seq[t_start]
+                t_end += 1
+            end
+            i = state_seq[t_start]
+            d = t_end - t_start + 1
+            durations = duration_distributions(hsmm, control_seq[t_start])
+            if t_end == t2
+                # Last segment of the sequence: right-censored, no outgoing transition.
+                logL += duration_logsurvival(durations[i], d)
+            else
+                logL += duration_logdensityof(durations[i], d)
+                trans = transition_matrix(hsmm, control_seq[t_end + 1])
+                logL += log(trans[i, state_seq[t_end + 1]])
+            end
+            t_start = t_end + 1
+        end
+    end
+    return logL
+end

--- a/src/inference/logdensity.jl
+++ b/src/inference/logdensity.jl
@@ -52,11 +52,11 @@ $(SIGNATURES)
 Compute the joint loglikelihood of `obs_seq` and `state_seq` for `hsmm`.
 
 Each constant-state segment contributes its sojourn length to its duration distribution. The
-control at the segment's first timestep determines both its duration distribution and the
-transition into it.
+control at the segment's first timestep determines its duration distribution, and the control at
+the first timestep of the next segment determines the transition into it.
 
-The final segment is right-censored and therefore contributes duration_logsurvival
-rather than duration_logdensityof.
+The final segment is right-censored and therefore contributes [`duration_logsurvival`](@ref)
+rather than [`duration_logdensityof`](@ref).
 """
 function joint_logdensityof(
     hsmm::AbstractHSMM,
@@ -70,20 +70,15 @@ function joint_logdensityof(
     for k in eachindex(seq_ends)
         t1, t2 = seq_limits(seq_ends, k)
         # Initialization
-        init = initialization(hsmm)
-        logL += log(init[state_seq[t1]])
+        loginit = log_initialization(hsmm)
+        logL += loginit[state_seq[t1]]
         # Observations
         for t in t1:t2
             dists = obs_distributions(hsmm, control_seq[t])
             logL += logdensityof(dists[state_seq[t]], obs_seq[t])
         end
         # Durations and transitions, segment by segment
-        t_start = t1
-        while t_start <= t2
-            t_end = t_start
-            while t_end < t2 && state_seq[t_end + 1] == state_seq[t_start]
-                t_end += 1
-            end
+        for (t_start, t_end) in StateSegments(state_seq, t1, t2)
             i = state_seq[t_start]
             d = t_end - t_start + 1
             durations = duration_distributions(hsmm, control_seq[t_start])
@@ -92,10 +87,9 @@ function joint_logdensityof(
                 logL += duration_logsurvival(durations[i], d)
             else
                 logL += duration_logdensityof(durations[i], d)
-                trans = transition_matrix(hsmm, control_seq[t_end + 1])
-                logL += log(trans[i, state_seq[t_end + 1]])
+                logtrans = log_transition_matrix(hsmm, control_seq[t_end + 1])
+                logL += logtrans[i, state_seq[t_end + 1]]
             end
-            t_start = t_end + 1
         end
     end
     return logL

--- a/src/types/abstract_hsmm.jl
+++ b/src/types/abstract_hsmm.jl
@@ -42,11 +42,9 @@ should implement
 
 - `Random.rand(rng, dist)` for sampling
 - `DensityInterface.logdensityof(dist, k)` for inference
+- [`duration_logsurvival`](@ref)`(dist, k)` for right-censoring the final segment of a sequence
 
-Optionally, it may also implement
-
-- [`duration_logsurvival`](@ref)`(dist, k)` for right-censoring. The generic fallback sums the
-  tail of `dist`, but a closed form is faster and avoids truncation.
+The last method is already provided for every `Distributions.DiscreteUnivariateDistribution`.
 """
 function duration_distributions end
 

--- a/src/types/abstract_hsmm.jl
+++ b/src/types/abstract_hsmm.jl
@@ -42,6 +42,11 @@ should implement
 
 - `Random.rand(rng, dist)` for sampling
 - `DensityInterface.logdensityof(dist, k)` for inference
+
+Optionally, it may also implement
+
+- [`duration_logsurvival`](@ref)`(dist, k)` for right-censoring. The generic fallback sums the
+  tail of `dist`, but a closed form is faster and avoids truncation.
 """
 function duration_distributions end
 

--- a/src/utils/duration.jl
+++ b/src/utils/duration.jl
@@ -28,3 +28,20 @@ function rand_duration(rng::AbstractRNG, dist)
 end
 
 rand_duration(dist) = rand_duration(default_rng(), dist)
+
+"""
+$(SIGNATURES)
+
+Return log P(sojourn time >= k) for the duration distribution dist.
+
+This is the right-censoring term for a sequence's final segment. It is computed from
+P(sojourn time <= k - 1) using duration_logdensityof, avoiding explicit summation
+over a potentially unbounded tail.
+"""
+function duration_logsurvival(dist, k::Integer)
+    log_head = oftype(duration_logdensityof(dist, one(k)), -Inf)
+    for d in one(k):(k - one(k))
+        log_head = logaddexp(log_head, duration_logdensityof(dist, d))
+    end
+    return log1mexp(min(log_head, zero(log_head)))
+end

--- a/src/utils/duration.jl
+++ b/src/utils/duration.jl
@@ -1,7 +1,3 @@
-# Stop once the tail converges numerically, with a hard limit for pathological distributions.
-const MAX_QUIET_TERMS = 64
-const MAX_TAIL_TERMS = 100_000
-
 """
 $(SIGNATURES)
 
@@ -14,7 +10,7 @@ of `(sojourn time - 1)`. The sojourn time itself lives on `{1, 2, 3, ...}`, so t
 `-Inf` through `dist` (e.g. a `Distributions.Distribution` returns `-Inf` for a negative
 argument).
 
-See also [`rand_duration`](@ref).
+See also [`rand_duration`](@ref) and [`duration_logsurvival`](@ref).
 """
 duration_logdensityof(dist, k::Integer) = logdensityof(dist, k - one(k))
 
@@ -34,27 +30,24 @@ end
 rand_duration(dist) = rand_duration(default_rng(), dist)
 
 """
-$(SIGNATURES)
+    duration_logsurvival(dist, k)
 
-Return `log ℙ(sojourn time >= k)` for the duration distribution `dist`.
+Return `log ℙ(sojourn time >= k)` for the duration distribution `dist`, following the
+convention of [`duration_logdensityof`](@ref) (the sojourn time lives on `{1, 2, 3, ...}`).
 
-This is the right-censoring term for the final segment of a sequence. The generic method sums the
-tail until it converges numerically; duration types may provide a closed form instead.
-"""
-function duration_logsurvival(dist, k::Integer)
-    # Every sojourn lasts at least one timestep.
-    k <= one(k) && return zero(duration_logdensityof(dist, one(k)))
-    log_tail = oftype(duration_logdensityof(dist, one(k)), -Inf)
-    quiet = 0
-    for d in k:(k + MAX_TAIL_TERMS)
-        new_tail = logaddexp(log_tail, duration_logdensityof(dist, d))
-        if new_tail == log_tail
-            quiet += 1
-            quiet >= MAX_QUIET_TERMS && break
-        else
-            quiet = 0
-        end
-        log_tail = new_tail
-    end
-    return log_tail
+This is the right-censoring term for the final segment of a sequence, whose sojourn is only
+known to last at least `k` timesteps. Since every sojourn lasts at least one timestep, the
+result must be `0` for `k <= 1`.
+
+A closed-form method based on `logccdf` is provided for every
+`Distributions.DiscreteUnivariateDistribution` when Distributions.jl is loaded. Custom duration
+distributions must implement this function themselves, for instance as
+
+```julia
+function HiddenMarkovModels.duration_logsurvival(dist::MyDuration, k::Integer)
+    k <= 1 && return 0.0
+    return log1p(-sum(exp(duration_logdensityof(dist, j)) for j in 1:(k - 1)))
 end
+```
+"""
+function duration_logsurvival end

--- a/src/utils/duration.jl
+++ b/src/utils/duration.jl
@@ -1,3 +1,7 @@
+# Stop once the tail converges numerically, with a hard limit for pathological distributions.
+const MAX_QUIET_TERMS = 64
+const MAX_TAIL_TERMS = 100_000
+
 """
 $(SIGNATURES)
 
@@ -32,16 +36,25 @@ rand_duration(dist) = rand_duration(default_rng(), dist)
 """
 $(SIGNATURES)
 
-Return log P(sojourn time >= k) for the duration distribution dist.
+Return `log ℙ(sojourn time >= k)` for the duration distribution `dist`.
 
-This is the right-censoring term for a sequence's final segment. It is computed from
-P(sojourn time <= k - 1) using duration_logdensityof, avoiding explicit summation
-over a potentially unbounded tail.
+This is the right-censoring term for the final segment of a sequence. The generic method sums the
+tail until it converges numerically; duration types may provide a closed form instead.
 """
 function duration_logsurvival(dist, k::Integer)
-    log_head = oftype(duration_logdensityof(dist, one(k)), -Inf)
-    for d in one(k):(k - one(k))
-        log_head = logaddexp(log_head, duration_logdensityof(dist, d))
+    # Every sojourn lasts at least one timestep.
+    k <= one(k) && return zero(duration_logdensityof(dist, one(k)))
+    log_tail = oftype(duration_logdensityof(dist, one(k)), -Inf)
+    quiet = 0
+    for d in k:(k + MAX_TAIL_TERMS)
+        new_tail = logaddexp(log_tail, duration_logdensityof(dist, d))
+        if new_tail == log_tail
+            quiet += 1
+            quiet >= MAX_QUIET_TERMS && break
+        else
+            quiet = 0
+        end
+        log_tail = new_tail
     end
-    return log1mexp(min(log_head, zero(log_head)))
+    return log_tail
 end

--- a/src/utils/duration.jl
+++ b/src/utils/duration.jl
@@ -37,7 +37,7 @@ convention of [`duration_logdensityof`](@ref) (the sojourn time lives on `{1, 2,
 
 This is the right-censoring term for the final segment of a sequence, whose sojourn is only
 known to last at least `k` timesteps. Since every sojourn lasts at least one timestep, the
-result must be `0` for `k <= 1`.
+result must be `0 = log(1)` for `k <= 1`.
 
 A closed-form method based on `logccdf` is provided for every
 `Distributions.DiscreteUnivariateDistribution` when Distributions.jl is loaded. Custom duration
@@ -49,5 +49,7 @@ function HiddenMarkovModels.duration_logsurvival(dist::MyDuration, k::Integer)
     return log1p(-sum(exp(duration_logdensityof(dist, j)) for j in 1:(k - 1)))
 end
 ```
+
+(but taking more precautions with numerical instabilities).
 """
 function duration_logsurvival end

--- a/src/utils/segments.jl
+++ b/src/utils/segments.jl
@@ -1,0 +1,26 @@
+"""
+    StateSegments(state_seq, t1, t2)
+
+Non-allocating iterator over the maximal constant-state runs of `state_seq[t1:t2]`.
+
+Each element is a tuple `(t_start, t_end)` such that `state_seq[t_start:t_end]` is constant and
+differs from its neighbors within `t1:t2`. Consecutive segments tile `t1:t2` in order.
+"""
+struct StateSegments{V<:AbstractVector}
+    state_seq::V
+    t1::Int
+    t2::Int
+end
+
+Base.IteratorSize(::Type{<:StateSegments}) = Base.SizeUnknown()
+Base.eltype(::Type{<:StateSegments}) = Tuple{Int,Int}
+
+function Base.iterate(segments::StateSegments, t_start::Int=segments.t1)
+    (; state_seq, t2) = segments
+    t_start > t2 && return nothing
+    t_end = t_start
+    while t_end < t2 && state_seq[t_end + 1] == state_seq[t_start]
+        t_end += 1
+    end
+    return (t_start, t_end), t_end + 1
+end

--- a/test/duration.jl
+++ b/test/duration.jl
@@ -13,14 +13,25 @@ struct ConstDuration{T} end
 DensityInterface.DensityKind(::ConstDuration) = HasDensity()
 DensityInterface.logdensityof(::ConstDuration, x) = iszero(x) ? 0.0 : -Inf
 Base.rand(::AbstractRNG, ::ConstDuration{T}) where {T} = zero(T)
+HiddenMarkovModels.duration_logsurvival(::ConstDuration, k::Integer) = k <= 1 ? 0.0 : -Inf
 
-# Forces dispatch to the generic tail summation.
+# Wraps a `Distributions` law without being one, so it must supply its own survival function.
+# It uses the two-line summation suggested in the `duration_logsurvival` docstring.
 struct DuckDuration{D}
     dist::D
 end
 DensityInterface.DensityKind(::DuckDuration) = HasDensity()
 DensityInterface.logdensityof(d::DuckDuration, x) = logdensityof(d.dist, x)
 Base.rand(rng::AbstractRNG, d::DuckDuration) = rand(rng, d.dist)
+function HiddenMarkovModels.duration_logsurvival(d::DuckDuration, k::Integer)
+    k <= 1 && return 0.0
+    return log1p(-sum(exp(duration_logdensityof(d, j)) for j in 1:(k - 1)))
+end
+
+# Implements the density but forgets the survival function.
+struct ForgetfulDuration end
+DensityInterface.DensityKind(::ForgetfulDuration) = HasDensity()
+DensityInterface.logdensityof(::ForgetfulDuration, x) = iszero(x) ? 0.0 : -Inf
 
 @testset "Duration convention" begin
     @testset "Shift relationship" begin
@@ -112,13 +123,19 @@ end
         end
     end
 
-    @testset "Generic fallback matches the closed-form method" begin
+    @testset "Custom user distribution (interface only)" begin
         @test duration_logsurvival(ConstDuration{Int}(), 1) == 0
         @test duration_logsurvival(ConstDuration{Int}(), 2) == -Inf
 
-        for dist in dists, k in 1:40
+        # The documented summation recipe agrees with the closed form.
+        # `log1p(-head)` loses precision as `head -> 1`, hence the relative tolerance.
+        for dist in dists, k in 1:20
             @test duration_logsurvival(DuckDuration(dist), k) ≈
-                duration_logsurvival(dist, k) atol = 1e-10
+                duration_logsurvival(dist, k) atol = 1e-8 rtol = 1e-6
         end
+    end
+
+    @testset "No silent fallback" begin
+        @test_throws MethodError duration_logsurvival(ForgetfulDuration(), 2)
     end
 end

--- a/test/duration.jl
+++ b/test/duration.jl
@@ -1,7 +1,7 @@
 using HiddenMarkovModels
-using HiddenMarkovModels: duration_logdensityof, rand_duration
+using HiddenMarkovModels: duration_logdensityof, duration_logsurvival, rand_duration
 using DensityInterface: DensityInterface, DensityKind, HasDensity, logdensityof
-using Distributions: Geometric, NegativeBinomial, Poisson
+using Distributions: DiscreteUniform, Geometric, NegativeBinomial, Poisson, logccdf
 using Random: AbstractRNG
 using StableRNGs: StableRNG
 using Statistics: mean
@@ -13,6 +13,14 @@ struct ConstDuration{T} end
 DensityInterface.DensityKind(::ConstDuration) = HasDensity()
 DensityInterface.logdensityof(::ConstDuration, x) = iszero(x) ? 0.0 : -Inf
 Base.rand(::AbstractRNG, ::ConstDuration{T}) where {T} = zero(T)
+
+# Forces dispatch to the generic tail summation.
+struct DuckDuration{D}
+    dist::D
+end
+DensityInterface.DensityKind(::DuckDuration) = HasDensity()
+DensityInterface.logdensityof(d::DuckDuration, x) = logdensityof(d.dist, x)
+Base.rand(rng::AbstractRNG, d::DuckDuration) = rand(rng, d.dist)
 
 @testset "Duration convention" begin
     @testset "Shift relationship" begin
@@ -65,5 +73,52 @@ Base.rand(::AbstractRNG, ::ConstDuration{T}) where {T} = zero(T)
         @test duration_logdensityof(d, 0) == -Inf
         @test rand_duration(StableRNG(1), d) == 1
         @test rand_duration(d) == 1  # default rng overload
+    end
+end
+
+@testset "Duration survival" begin
+    dists = (Poisson(3.0), Geometric(0.5), Geometric(0.05), NegativeBinomial(3.0, 0.4))
+
+    @testset "Agrees with the closed form far into the tail" begin
+        for dist in dists, k in 1:80
+            exact = k <= 1 ? 0.0 : logccdf(dist, k - 2)
+            @test duration_logsurvival(dist, k) ≈ exact atol = 1e-10
+        end
+    end
+
+    @testset "Every sojourn lasts at least one timestep" begin
+        for dist in (dists..., Geometric(1.0), DiscreteUniform(0, 5))
+            @test duration_logsurvival(dist, 1) == 0
+            @test duration_logsurvival(dist, 0) == 0
+        end
+    end
+
+    @testset "Bounded support runs out" begin
+        d = DiscreteUniform(0, 5)
+        @test duration_logsurvival(d, 6) ≈ log(1 / 6)
+        @test duration_logsurvival(d, 7) == -Inf
+        @test duration_logsurvival(d, 50) == -Inf
+    end
+
+    @testset "Degenerate law" begin
+        @test duration_logsurvival(Geometric(1.0), 1) == 0
+        @test duration_logsurvival(Geometric(1.0), 2) == -Inf
+    end
+
+    @testset "Consistent with the duration density" begin
+        for dist in dists, k in 1:15
+            s1, s2 = duration_logsurvival(dist, k), duration_logsurvival(dist, k + 1)
+            @test exp(s1) - exp(s2) ≈ exp(duration_logdensityof(dist, k)) atol = 1e-12
+        end
+    end
+
+    @testset "Generic fallback matches the closed-form method" begin
+        @test duration_logsurvival(ConstDuration{Int}(), 1) == 0
+        @test duration_logsurvival(ConstDuration{Int}(), 2) == -Inf
+
+        for dist in dists, k in 1:40
+            @test duration_logsurvival(DuckDuration(dist), k) ≈
+                duration_logsurvival(dist, k) atol = 1e-10
+        end
     end
 end

--- a/test/duration.jl
+++ b/test/duration.jl
@@ -92,7 +92,7 @@ end
 
     @testset "Agrees with the closed form far into the tail" begin
         for dist in dists, k in 1:80
-            exact = k <= 1 ? 0.0 : logccdf(dist, k - 2)
+            exact = logccdf(dist, k - 2)
             @test duration_logsurvival(dist, k) ≈ exact atol = 1e-10
         end
     end

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -1,15 +1,18 @@
-using DensityInterface: DensityKind, HasDensity
+using DensityInterface: DensityInterface, DensityKind, HasDensity, logdensityof
 using HiddenMarkovModels
 using HiddenMarkovModels:
     AbstractLatentStateModel,
     AbstractHSMM,
     duration_distributions,
+    duration_logdensityof,
+    duration_logsurvival,
     duration_logdensity_type,
     elementwise_log,
     log_initialization,
     log_transition_matrix,
     valid_hsmm
 using Distributions: Geometric, Normal
+using Random: AbstractRNG
 using StableRNGs: StableRNG
 using Test
 
@@ -139,5 +142,90 @@ end
         @test !hasproperty(out, :duration_seq)
         @test length(out.state_seq) == 50
         @test length(out.obs_seq) == 50
+    end
+end
+
+@testset "HSMM joint_logdensityof" begin
+    init = [0.6, 0.4]
+    trans = [0.0 1.0; 1.0 0.0]
+    dists = [Normal(0.0, 1.0), Normal(5.0, 1.0)]
+    dur_dists = [Geometric(0.4), Geometric(0.6)]
+
+    @testset "Hand-computed value" begin
+        hsmm = HSMM(init, trans, dists, dur_dists)
+        # states [1, 1, 2] = one full segment (state 1, length 2), then a censored
+        # final segment (state 2, length 1 observed).
+        state_seq = [1, 1, 2]
+        obs_seq = [0.3, -0.1, 5.2]
+        expected =
+            log(init[1]) +
+            duration_logdensityof(dur_dists[1], 2) +
+            log(trans[1, 2]) +
+            duration_logsurvival(dur_dists[2], 1) +
+            logdensityof(dists[1], obs_seq[1]) +
+            logdensityof(dists[1], obs_seq[2]) +
+            logdensityof(dists[2], obs_seq[3])
+        @test joint_logdensityof(hsmm, obs_seq, state_seq) ≈ expected
+    end
+
+    @testset "Survival term" begin
+        d = Geometric(0.4)
+        # P(D >= 1) == 1 for any sojourn distribution.
+        @test duration_logsurvival(d, 1) ≈ 0.0
+        # P(D >= k) == 1 - sum_{j < k} P(D == j), by construction.
+        for k in 1:6
+            head = sum(exp(duration_logdensityof(d, j)) for j in 1:(k - 1); init=0.0)
+            @test duration_logsurvival(d, k) ≈ log1p(-head)
+        end
+        # Geometric sojourns have the closed form P(D >= k) == (1 - p)^(k - 1).
+        for k in 1:6
+            @test duration_logsurvival(d, k) ≈ (k - 1) * log(1 - 0.4)
+        end
+    end
+
+    @testset "Exact equivalence with an HMM under geometric sojourns" begin
+        #= An HMM with self-transition probability A[i, i] is exactly an HSMM with
+        geometric sojourns and the self-transitions renormalized away. The equality
+        below holds only because the final segment is right-censored. =#
+        hmm_trans = [0.7 0.2 0.1; 0.3 0.5 0.2; 0.25 0.25 0.5]
+        hmm_init = [0.5, 0.3, 0.2]
+        hmm_dists = [Normal(0.0), Normal(5.0), Normal(10.0)]
+        hmm = HMM(hmm_init, hmm_trans, hmm_dists)
+
+        N = length(hmm_init)
+        hsmm_trans = [
+            i == j ? 0.0 : hmm_trans[i, j] / (1 - hmm_trans[i, i]) for i in 1:N, j in 1:N
+        ]
+        hsmm_durs = [Geometric(1 - hmm_trans[i, i]) for i in 1:N]
+        hsmm = HSMM(hmm_init, hsmm_trans, hmm_dists, hsmm_durs)
+
+        rng = StableRNG(63)
+        for _ in 1:20
+            (; state_seq, obs_seq) = rand(rng, hmm, 12)
+            @test joint_logdensityof(hsmm, obs_seq, state_seq) ≈
+                joint_logdensityof(hmm, obs_seq, state_seq)
+        end
+    end
+
+    @testset "Multiple sequences" begin
+        hsmm = HSMM(init, trans, dists, dur_dists)
+        rng = StableRNG(15)
+        sims = [rand(rng, hsmm, T) for T in (4, 7, 5)]
+        obs_seq = reduce(vcat, sim.obs_seq for sim in sims)
+        state_seq = reduce(vcat, sim.state_seq for sim in sims)
+        seq_ends = cumsum([length(sim.obs_seq) for sim in sims])
+        @test joint_logdensityof(hsmm, obs_seq, state_seq; seq_ends) ≈
+            sum(joint_logdensityof(hsmm, sim.obs_seq, sim.state_seq) for sim in sims)
+    end
+
+    @testset "Type promotion" begin
+        hsmm32 = HSMM(
+            Float32[0.6, 0.4],
+            Float32[0.0 1.0; 1.0 0.0],
+            [Normal(0.0f0, 1.0f0), Normal(5.0f0, 1.0f0)],
+            dur_dists,
+        )
+        # Float32 model with Float64 duration distributions promotes to Float64.
+        @test joint_logdensityof(hsmm32, [0.0f0, 5.0f0], [1, 2]) isa Float64
     end
 end

--- a/test/hsmm.jl
+++ b/test/hsmm.jl
@@ -8,6 +8,7 @@ using HiddenMarkovModels:
     duration_logsurvival,
     duration_logdensity_type,
     elementwise_log,
+    StateSegments,
     log_initialization,
     log_transition_matrix,
     valid_hsmm
@@ -143,6 +144,22 @@ end
         @test length(out.state_seq) == 50
         @test length(out.obs_seq) == 50
     end
+end
+
+# Summing over the iterator inside a function so `@allocated` measures only the iteration.
+function total_span(state_seq, t1, t2)
+    return sum(t_end - t_start + 1 for (t_start, t_end) in StateSegments(state_seq, t1, t2))
+end
+
+@testset "State segments" begin
+    @test collect(StateSegments([1, 1, 2, 2, 2, 1], 1, 6)) == [(1, 2), (3, 5), (6, 6)]
+    @test collect(StateSegments([1, 1, 2, 2, 2, 1], 2, 4)) == [(2, 2), (3, 4)]
+    @test collect(StateSegments([3], 1, 1)) == [(1, 1)]
+    @test isempty(collect(StateSegments([1, 2], 2, 1)))
+    @test eltype(StateSegments([1, 2], 1, 2)) == Tuple{Int,Int}
+    state_seq = [1, 1, 2, 2, 2, 1]
+    @test total_span(state_seq, 1, 6) == 6
+    @test iszero(@allocated total_span(state_seq, 1, 6))
 end
 
 @testset "HSMM joint_logdensityof" begin


### PR DESCRIPTION
Adds `joint_logdensityof` specific to the HSMM and a `duration_logsurvival` function to handle the right censoring convention of the HSMM model (i.e., when a duration is sampled but the sequence truncates at `T`). Also adds tests for these functions